### PR TITLE
CI: install package in backend jobs for daemon namespace resolution

### DIFF
--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -71,7 +71,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::testthat, stan-dev/cmdstanr
+          # local::. installs the package so mirai daemons can resolve the
+          # bayesim namespace; tests still run against the source tree.
+          extra-packages: any::testthat, stan-dev/cmdstanr, local::.
           needs: check
 
       - name: Fix CmdStan toolchain

--- a/.github/workflows/test-backend.yaml
+++ b/.github/workflows/test-backend.yaml
@@ -27,7 +27,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::testthat, stan-dev/cmdstanr
+          # local::. installs the package so mirai daemons can resolve the
+          # bayesim namespace; tests still run against the source tree.
+          extra-packages: any::testthat, stan-dev/cmdstanr, local::.
           needs: check
 
       - name: Fix CmdStan toolchain


### PR DESCRIPTION
The first `test-backend` run on master (31953511565) failed: 30 SBC-acceptance tasks died with `could not find function "run_task"` because mirai daemons cannot resolve bayesim internals when the controller tests the source tree without an installed package. `test-fast` already installs `local::.` for exactly this; extend it to `test-backend` and the release `backend-acceptance` job. The two downstream assertion failures in the log are cascades of the empty result.