### PR TITLE
Print an end-of-run summary with resume instructions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
 
+## Runtime UX
+
+* `run_simulation()` now prints a single end-of-run summary block when
+  `verbose = TRUE`: completion status, task counts (succeeded, failed, not
+  run), the stop reason for early stops (`max_errors` or adaptive
+  stopping), the results path, and — when unexecuted work remains — the
+  literal `resume_simulation()` command for that run. The block subsumes
+  the former standalone failure summary.
+
 ## Engine and resume
 
 * Fixed the legacy-resume truth/diagnostics round-trip: resumed runs no

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
 
 ## Engine and resume
 
+* Fixed a `merge_results()` crash on resume-to-completion: when the resumed
+  execution re-covered every prior task and the new rows carried columns the
+  prior rows lacked (e.g. diagnostics after a failed-only prior run), the
+  schema-alignment step assigned a length-1 `NA` into a 0-row frame (#63).
 * Fixed the legacy-resume truth/diagnostics round-trip: resumed runs no
   longer lose or mangle recorded truths and fit diagnostics when prior task
   results are reloaded from a checkpoint.

--- a/R/resume.R
+++ b/R/resume.R
@@ -347,13 +347,15 @@ merge_results <- function(prior_results, new_results) {
   # Checkpoints from adjacent schema versions may differ only by an all-NA
   # optional column. Align the union before binding so an equivalent duplicate
   # can be replaced by the new row without making unrelated prior rows
-  # impossible to retain.
+  # impossible to retain. Assign row-count-length NA vectors: a bare NA errors
+  # when the receiving side is a 0-row frame, which happens when the resumed
+  # execution re-covers every prior task (resume-to-completion; #63).
   all_cols <- union(names(prior_only), names(new_results))
   for (col in setdiff(all_cols, names(prior_only))) {
-    prior_only[[col]] <- NA
+    prior_only[[col]] <- rep(NA, nrow(prior_only))
   }
   for (col in setdiff(all_cols, names(new_results))) {
-    new_results[[col]] <- NA
+    new_results[[col]] <- rep(NA, nrow(new_results))
   }
   combined <- rbind(
     prior_only[, all_cols, drop = FALSE],

--- a/R/runtime-ux.R
+++ b/R/runtime-ux.R
@@ -323,6 +323,95 @@ print_failure_summary <- function(result) {
   invisible(NULL)
 }
 
+# F7: end-of-run summary ----------------------------------------------------
+
+# Human phrasing for the stop_reason values execute_tasks() records on tasks
+# that were never executed (policy-stopped work is resumable by design).
+format_stop_reasons <- function(reasons) {
+  labels <- c(
+    max_errors = "error budget exhausted",
+    adaptive_stop = "adaptive stopping target reached"
+  )
+  known <- labels[reasons]
+  unknown <- is.na(known)
+  if (any(unknown)) {
+    known[unknown] <- reasons[unknown]
+  }
+  paste(unique(known), collapse = "; ")
+}
+
+# Print the single end-of-run block: completion status, task counts, stop
+# reason, results path, and — when unexecuted work remains — the literal
+# resume command (truthful about configless resume, see resume_guidance_lines),
+# followed by the per-class failure detail. Called by run_simulation() when
+# verbose = TRUE; independent of the task progress bar.
+print_run_summary <- function(result) {
+  grid <- result$task_grid
+  statuses <- if (is.data.frame(grid) && nrow(grid) > 0L) {
+    grid$status
+  } else {
+    vapply(
+      result$task_results,
+      function(tr) if (is.null(tr)) "pending" else tr$status,
+      character(1)
+    )
+  }
+  n_total <- length(statuses)
+  n_success <- sum(statuses == "success", na.rm = TRUE)
+  n_failed <- sum(statuses == "failed", na.rm = TRUE)
+  n_remaining <- sum(is.na(statuses) | statuses %in% TASK_RESUMABLE_STATUSES)
+  elapsed <- round(result$timing$total, 1)
+
+  if (n_remaining == 0L) {
+    if (n_failed == 0L) {
+      cli::cli_alert_success(
+        "Simulation complete: {n_success}/{n_total} tasks succeeded in {elapsed}s"
+      )
+    } else {
+      cli::cli_alert_warning(
+        "Simulation finished: {n_success}/{n_total} tasks succeeded, {n_failed} failed in {elapsed}s"
+      )
+    }
+  } else {
+    reasons <- if (
+      is.data.frame(grid) &&
+        nrow(grid) > 0L &&
+        "stop_reason" %in% names(grid)
+    ) {
+      unique(stats::na.omit(grid$stop_reason))
+    } else {
+      character()
+    }
+    reason <- if (length(reasons) > 0L) {
+      format_stop_reasons(reasons)
+    } else {
+      "stopped early"
+    }
+    cli::cli_alert_warning(
+      "Simulation stopped early ({reason}): {n_success} succeeded, {n_failed} failed, {n_remaining} of {n_total} tasks not run"
+    )
+  }
+
+  if (!is.null(result$checkpoint_path)) {
+    path <- normalizePath(
+      result$checkpoint_path,
+      winslash = "/",
+      mustWork = FALSE
+    )
+    cli::cli_text("Results: {path}")
+    if (n_remaining > 0L) {
+      # verbatim: the guidance lines are pre-formatted (own indentation, no
+      # cli markup), and paths may contain characters cli would interpolate.
+      for (line in resume_guidance_lines(path)) {
+        cli::cli_verbatim(line)
+      }
+    }
+  }
+
+  print_failure_summary(result)
+  invisible(NULL)
+}
+
 # F3: as_tibble for simulation results ------------------------------------
 
 # Registered as an S3 method for tibble::as_tibble via registerS3method on load

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -307,12 +307,11 @@ run_simulation <- function(
     checkpoint_path = run_policy$result_path
   )
 
-  # F2: compact failure summary when any task failed.
-  if (
-    !is.null(result$summary) &&
-      any(result$summary$status == "failed", na.rm = TRUE)
-  ) {
-    if (isTRUE(verbose)) print_failure_summary(result)
+  # F7 (issue #53): one end-of-run block — completion status, task counts,
+  # stop reason, results path, and the literal resume command when work
+  # remains. Subsumes the F2 failure detail. Gated by verbose only.
+  if (isTRUE(verbose)) {
+    print_run_summary(result)
   }
 
   result

--- a/tests/testthat/test-checkpoint.R
+++ b/tests/testthat/test-checkpoint.R
@@ -1260,6 +1260,33 @@ describe("Resume Logic", {
       expect_equal(result$metric_rmse[result$task_id == "t2"], 0.10)
     })
 
+    it("handles a resume that re-covers every prior task with new columns", {
+      # Regression test for #63: execute_tasks() flattens restored prior
+      # outcomes alongside re-run ones, so a resume-to-completion presents
+      # every prior task_id as a duplicate. prior_only is then a 0-row frame,
+      # and the schema-alignment loops must still add columns only the new
+      # rows carry (a bare NA assignment into 0 rows used to error).
+      old_results <- data.frame(
+        task_id = c("t1", "t2"),
+        status = c("failed", "skipped"),
+        stringsAsFactors = FALSE
+      )
+      new_results <- data.frame(
+        task_id = c("t1", "t2", "t3"),
+        status = c("failed", "success", "success"),
+        # The restored failed row carries no value (NA on both sides counts
+        # as equivalent); the re-run successes carry real values.
+        truth__x = c(NA_real_, 1, 2),
+        stringsAsFactors = FALSE
+      )
+
+      result <- merge_results(old_results, new_results)
+
+      expect_equal(result$task_id, c("t1", "t2", "t3"))
+      expect_equal(result$status, c("failed", "success", "success"))
+      expect_equal(result$truth__x, c(NA_real_, 1, 2))
+    })
+
     it("accepts resume-equivalent rows despite timing and missing-value representation", {
       old_results <- data.frame(
         task_id = c("t1", "t2"),

--- a/tests/testthat/test-runtime-ux.R
+++ b/tests/testthat/test-runtime-ux.R
@@ -148,9 +148,11 @@ describe("F5 run reporting", {
 })
 
 describe("F7 end-of-run summary", {
-  # cli alerts signal message or warning conditions depending on level;
-  # run verbosely, collect every emitted condition into one searchable text
-  # block, and return the result alongside it.
+  # All cli alerts (any visual level) signal cliMessage conditions, which
+  # inherit from "message"; the warning handler additionally collects genuine
+  # warnings the run may emit (e.g. cli_warn). Run verbosely, collect every
+  # emitted condition into one searchable text block, and return the result
+  # alongside it.
   .run_messages <- function(config, ...) {
     conds <- character()
     result <- withCallingHandlers(
@@ -278,6 +280,63 @@ describe("F7 end-of-run summary", {
     )
     expect_match(out$text, "tasks not run")
     expect_match(out$text, "Resume with: resume_simulation", fixed = TRUE)
+  })
+
+  it("reports cumulative counts after resuming to completion", {
+    path <- withr::local_tempdir()
+    # Fails the first replicate only: run 1 exhausts the error budget on the
+    # rep-1 failure, and resume re-runs the remaining (skipped) replicates,
+    # which succeed.
+    flaky_gen <- function(data_spec, task_ctx) {
+      if (identical(task_ctx$rep_idx, 1L)) {
+        stop("Intentional failure")
+      }
+      n <- data_spec$n
+      x <- stats::rnorm(n)
+      y <- x + stats::rnorm(n)
+      list(
+        train = data.frame(y = y, x = x),
+        test = NULL,
+        response = "y",
+        true_params = c(x = 1),
+        vars_of_interest = "x",
+        meta = list()
+      )
+    }
+    config <- simulation_config(
+      data_grid = data.frame(n = 20),
+      fit_grid = data.frame(model = "lm"),
+      data_generator = flaky_gen,
+      fitter = LinearRegressionFitter(n_draws = 20L),
+      metrics = list(),
+      n_replicates = 4L,
+      seed = 46L,
+      max_errors = 1L,
+      checkpoint_every = 1L,
+      result_path = file.path(path, "flaky")
+    )
+    stopped <- .run_messages(config, resume = "never", progress = FALSE)
+    expect_match(
+      stopped$text,
+      "Simulation stopped early \\(error budget exhausted\\): 0 succeeded, 1 failed, 3 of 4 tasks not run"
+    )
+
+    # Raising the error budget is runtime policy, so the same study resumes
+    # compatibly. The advertised resume path completes the study: counts are
+    # cumulative across the resume (the prior failure is terminal), and the
+    # completion block offers no resume command.
+    config@max_errors <- Inf
+    resumed <- .run_messages(
+      config,
+      resume = "must",
+      progress = FALSE
+    )
+    expect_match(
+      resumed$text,
+      "Simulation finished: 3/4 tasks succeeded, 1 failed"
+    )
+    expect_false(grepl("Resume with", resumed$text, fixed = TRUE))
+    expect_match(resumed$text, "Results:", fixed = TRUE)
   })
 
   it("stays silent when verbose = FALSE", {

--- a/tests/testthat/test-runtime-ux.R
+++ b/tests/testthat/test-runtime-ux.R
@@ -147,6 +147,183 @@ describe("F5 run reporting", {
   })
 })
 
+describe("F7 end-of-run summary", {
+  # cli alerts signal message or warning conditions depending on level;
+  # run verbosely, collect every emitted condition into one searchable text
+  # block, and return the result alongside it.
+  .run_messages <- function(config, ...) {
+    conds <- character()
+    result <- withCallingHandlers(
+      run_simulation(config, ...),
+      message = function(m) {
+        conds <<- c(conds, conditionMessage(m))
+        invokeRestart("muffleMessage")
+      },
+      warning = function(w) {
+        conds <<- c(conds, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      }
+    )
+    list(text = paste(conds, collapse = "\n"), result = result)
+  }
+
+  it("prints completion, counts, and path; no resume line when done", {
+    path <- withr::local_tempdir()
+    config <- simulation_config(
+      data_grid = data.frame(n = 20),
+      fit_grid = data.frame(model = "lm"),
+      data_generator = .gen,
+      fitter = LinearRegressionFitter(n_draws = 20L),
+      metrics = list(),
+      n_replicates = 2L,
+      seed = 41L,
+      result_path = file.path(path, "complete")
+    )
+    out <- .run_messages(config, resume = "never", progress = FALSE)
+
+    expect_match(out$text, "Simulation complete: 2/2 tasks succeeded")
+    expect_match(out$text, "Results:", fixed = TRUE)
+    # Nothing left to resume: no resume instruction in the completed block.
+    expect_false(grepl("Resume with", out$text, fixed = TRUE))
+    expect_s3_class(out$result, "bayesim_simulation_result")
+  })
+
+  it("reports failed counts and per-class detail for a finished run", {
+    config <- simulation_config(
+      data_grid = data.frame(n = 20),
+      fit_grid = data.frame(model = "lm"),
+      data_generator = function(data_spec, task_ctx) {
+        stop("Intentional failure")
+      },
+      fitter = LinearRegressionFitter(n_draws = 20L),
+      metrics = list(),
+      n_replicates = 3L,
+      seed = 42L,
+      max_errors = Inf
+    )
+    out <- .run_messages(config, resume = "never", progress = FALSE)
+
+    expect_match(out$text, "Simulation finished: 0/3 tasks succeeded, 3 failed")
+    expect_match(out$text, "3 task(s) failed", fixed = TRUE)
+    # All tasks are terminal: no resume instruction.
+    expect_false(grepl("Resume with", out$text, fixed = TRUE))
+  })
+
+  it("prints remaining work and the literal resume call after max_errors", {
+    path <- withr::local_tempdir()
+    config <- simulation_config(
+      data_grid = data.frame(n = 20),
+      fit_grid = data.frame(model = "lm"),
+      data_generator = function(data_spec, task_ctx) {
+        stop("Intentional failure")
+      },
+      fitter = LinearRegressionFitter(n_draws = 20L),
+      metrics = list(),
+      n_replicates = 4L,
+      seed = 43L,
+      max_errors = 1L,
+      result_path = file.path(path, "stopped")
+    )
+    out <- .run_messages(config, resume = "never", progress = FALSE)
+
+    expect_match(
+      out$text,
+      "Simulation stopped early \\(error budget exhausted\\): 0 succeeded, 1 failed, 3 of 4 tasks not run"
+    )
+    # The exact, copyable resume command for this run's path.
+    expect_match(out$text, 'Resume with: resume_simulation\\("[^"]+/stopped"')
+    expect_false(grepl("Simulation complete", out$text, fixed = TRUE))
+    expect_equal(sum(out$result$task_grid$status == "skipped"), 3L)
+  })
+
+  it("labels adaptive stops and prints the resume call", {
+    path <- withr::local_tempdir()
+    .conj_gen <- function(data_spec, task_ctx) {
+      n <- data_spec$n
+      b <- data_spec$beta
+      x <- stats::rnorm(n)
+      y <- 1 + b * x + stats::rnorm(n)
+      list(
+        train = data.frame(y = y, x = x),
+        test = NULL,
+        response = "y",
+        true_params = c(Intercept = 1, x = b, sigma = 1),
+        vars_of_interest = c("Intercept", "x", "sigma"),
+        meta = list()
+      )
+    }
+    config <- simulation_config(
+      data_grid = data.frame(n = 60L, beta = c(0.5, 1)),
+      fit_grid = data.frame(model = "lm"),
+      data_generator = .conj_gen,
+      fitter = LinearRegressionFitter(n_draws = 100L),
+      metrics = list(posterior_summary_metric()),
+      n_replicates = 6L,
+      seed = 44L,
+      result_path = file.path(path, "adaptive"),
+      checkpoint_every = 2L,
+      stop_on = list(
+        estimand = "x",
+        measure = "bias",
+        target_mcse = 100,
+        min_reps = 2L,
+        check_every = 2L
+      )
+    )
+    out <- .run_messages(config, resume = "never", progress = FALSE)
+
+    expect_match(
+      out$text,
+      "Simulation stopped early \\(adaptive stopping target reached\\)"
+    )
+    expect_match(out$text, "tasks not run")
+    expect_match(out$text, "Resume with: resume_simulation", fixed = TRUE)
+  })
+
+  it("stays silent when verbose = FALSE", {
+    path <- withr::local_tempdir()
+    config <- simulation_config(
+      data_grid = data.frame(n = 20),
+      fit_grid = data.frame(model = "lm"),
+      data_generator = function(data_spec, task_ctx) {
+        stop("Intentional failure")
+      },
+      fitter = LinearRegressionFitter(n_draws = 20L),
+      metrics = list(),
+      n_replicates = 4L,
+      seed = 45L,
+      max_errors = 1L,
+      result_path = file.path(path, "quiet")
+    )
+    expect_silent(
+      run_simulation(
+        config,
+        resume = "never",
+        progress = FALSE,
+        verbose = FALSE
+      )
+    )
+  })
+
+  it("falls back to task results when the grid is absent", {
+    tr <- new_task_result(
+      task_id = "t1",
+      status = "success",
+      metrics = list(),
+      timing = list(total = 0.1)
+    )
+    result <- new_simulation_result(
+      config_fingerprint = "abc",
+      task_results = list(tr),
+      timing = list(total = 0.2)
+    )
+    expect_message(
+      print_run_summary(result),
+      "Simulation complete: 1/1 tasks succeeded"
+    )
+  })
+})
+
 describe("F6 truthful resume instructions", {
   configless_line <- 'Resume with: resume_simulation\\("[^"]+"\\)$'
 


### PR DESCRIPTION
## Summary

Closes #53. Also fixes #63 (a pre-existing resume crash uncovered by the new tests).

`run_simulation()` now ends every verbose run with a single summary block (new internal `print_run_summary()` in `R/runtime-ux.R`, wired into the tail of `run_simulation()` and gated by `verbose` only, independent of `progress`):

- **Completion status + counts**: `Simulation complete: N/N tasks succeeded in Xs` for clean runs; `Simulation finished: N/M tasks succeeded, K failed` when the grid finished with failures.
- **Early stops**: `Simulation stopped early (<reason>): a succeeded, b failed, c of d tasks not run`, with the reason derived from the task grid's `stop_reason` (`max_errors` → "error budget exhausted", `adaptive_stop` → "adaptive stopping target reached"; unknown/future reasons fall back to their raw value).
- **Results path** (when a `result_path` was configured).
- **The literal resume command** — but only when unexecuted work remains, reusing the truthful `resume_guidance_lines()`: configless `resume_simulation("<path>")` when the run manifest can rehydrate every executable component, the `config = config` variant otherwise.
- The per-class failure detail (former standalone `print_failure_summary()` output) is folded into the block.

`verbose = FALSE` stays fully silent; the `print()` method's own reporting is unchanged.

## Example

```
! Simulation stopped early (error budget exhausted): 0 succeeded, 1 failed, 3 of 4 tasks not run
Results: /tmp/runs/stopped
  Resume with: resume_simulation("/tmp/runs/stopped", config = config)
  (`config` is the original SimulationConfig object used to create this run)
  Manifest cannot restore: data_generator; supply the config used to create this run.
! 1 task(s) failed:
"bayesim_data_error, bayesim_error, error, condition": Intentional failure
```

## Resume-to-completion fix (#63)

The new test that follows the printed resume command uncovered a pre-existing crash: on resume-to-completion, restored prior outcomes are flattened into `new_results`, so every `prior_results` row is a duplicate, `prior_only` becomes a 0-row frame, and `merge_results()`'s schema-alignment loops crashed assigning length-1 `NA` into it whenever the new rows carried columns the prior rows lacked (diagnostics/truth after a failed-only prior run). Fixed by assigning row-count-length `NA` vectors; reproduced independently of this PR's changes before the fix.

## Tests

New `F7 end-of-run summary` block in `tests/testthat/test-runtime-ux.R` (fast tier): completed run (counts + path, no resume line), finished-with-failures run, `max_errors` stop (exact remaining counts + copyable resume command for the run's path), **resume-to-completion** (budget raised to `Inf` — runtime policy — then cumulative counts and no resume line), adaptive stop (reason label + resume line), `verbose = FALSE` silence, and the task-grid-absent fallback. cli alerts always signal message-class conditions, so the tests collect conditions with `withCallingHandlers` instead of capturing stdout.

## Verification

- `run_bayesim_test_tier("core")`: all pass (also after the `merge_results()` fix)
- `jarl check .`: clean
- `air format . --check`: clean
- `R CMD check --as-cran`: 0 errors, only the known S7 codoc WARNING (#56) + incoming-feasibility NOTE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consolidated end-of-run summary showing completion status, task counts, stop reason, elapsed time, results location, and resume guidance.
  * Added detailed failure breakdowns for runs that encounter errors.
* **Bug Fixes**
  * Fixed resume scenarios that previously failed when completing work with new result columns and no prior rows.
  * Improved preservation and alignment of result data during resume operations.
* **Documentation**
  * Documented the new runtime summary and resume-related fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->