### PR TITLE
Keep stop_reason labels when a resumed run stops before executing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,14 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
 
 ## Engine and resume
 
+* Resumed task grids no longer lose policy-stop labels when the resumed run
+  stops before executing anything (e.g. the carried-over failure count
+  already exhausts an unchanged `max_errors` budget): tasks restored from
+  the checkpoint are re-marked `skipped` with the run's stop reason instead
+  of staying `pending`/`NA`, so the result grid and the end-of-run summary
+  report the specific reason rather than the generic fallback (#64).
+  `merge_task_grid_status()` also carries a recorded `stop_reason` for
+  terminal rows instead of dropping the column's values.
 * Fixed a `merge_results()` crash on resume-to-completion: when the resumed
   execution re-covered every prior task and the new rows carried columns the
   prior rows lacked (e.g. diagnostics after a failed-only prior run), the

--- a/R/resume.R
+++ b/R/resume.R
@@ -234,9 +234,12 @@ validate_resume_retention <- function(requested, persisted, checkpoint) {
 #'
 #' @details
 #' The function preserves the deterministic task ordering and RNG seeds
-#' from the fresh grid, only updating status for tasks that were terminal
-#' in the checkpoint. This ensures resumed runs maintain identical
-#' reproducibility guarantees.
+#' from the fresh grid, only updating status (and any recorded
+#' `stop_reason`) for tasks that were terminal in the checkpoint. This
+#' ensures resumed runs maintain identical reproducibility guarantees.
+#' Policy-stopped rows return to pending with no stop reason; a resumed
+#' run that stops before executing them re-marks them in
+#' [execute_tasks()].
 #'
 #' @keywords internal
 merge_task_grid_status <- function(fresh_grid, checkpoint_grid) {
@@ -269,6 +272,20 @@ merge_task_grid_status <- function(fresh_grid, checkpoint_grid) {
   hit <- match(task_ids, names(status_lookup))
   hit_ids <- which(!is.na(hit))
   fresh_grid$status[hit_ids] <- unname(status_lookup)[hit[hit_ids]]
+
+  # Carry the recorded stop reason for merged terminal rows so the resumed
+  # grid does not silently drop it. Rows reset to pending stay NA here;
+  # execute_tasks() re-labels them if this run stops before executing them.
+  if ("stop_reason" %in% names(checkpoint_grid)) {
+    if (!"stop_reason" %in% names(fresh_grid)) {
+      fresh_grid$stop_reason <- NA_character_
+    }
+    reason_lookup <- stats::setNames(
+      as.character(terminal_tasks$stop_reason),
+      terminal_tasks$task_id
+    )
+    fresh_grid$stop_reason[hit_ids] <- unname(reason_lookup)[hit[hit_ids]]
+  }
 
   fresh_grid
 }

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -679,11 +679,20 @@ execute_tasks <- function(
     }
   }
 
-  # After the main loop, fill any remaining NULL slots with policy-stopped
-  # outcomes. These rows are deliberately not terminal on resume.
+  # After the main loop, fill every task this invocation did not execute with
+  # a policy-stopped outcome. These rows are deliberately not terminal on
+  # resume. Besides NULL slots (never reached), that includes placeholders
+  # restored from a prior checkpoint: their slots are non-NULL, but the merge
+  # reset their grid rows to pending, so they must be re-marked when the
+  # resumed run stops before executing them (#64). Placeholders this loop
+  # marked inline for an adaptive stop (grid row already skipped) keep their
+  # more specific message.
   for (i in seq_along(task_results)) {
+    unexecuted <- is.null(task_results[[i]]) ||
+      (identical(task_grid$status[i], "pending") &&
+        identical(task_results[[i]]$status, "skipped"))
     if (
-      is.null(task_results[[i]]) &&
+      unexecuted &&
         is_resumable_task_status(task_grid$status[i])
     ) {
       task_grid$status[i] <- "skipped"

--- a/man/merge_task_grid_status.Rd
+++ b/man/merge_task_grid_status.Rd
@@ -21,8 +21,11 @@ were completed (success/failed/skipped) in the checkpoint are updated.
 }
 \details{
 The function preserves the deterministic task ordering and RNG seeds
-from the fresh grid, only updating status for tasks that were terminal
-in the checkpoint. This ensures resumed runs maintain identical
-reproducibility guarantees.
+from the fresh grid, only updating status (and any recorded
+\code{stop_reason}) for tasks that were terminal in the checkpoint. This
+ensures resumed runs maintain identical reproducibility guarantees.
+Policy-stopped rows return to pending with no stop reason; a resumed
+run that stops before executing them re-marks them in
+\code{\link[=execute_tasks]{execute_tasks()}}.
 }
 \keyword{internal}

--- a/tests/testthat/test-checkpoint.R
+++ b/tests/testthat/test-checkpoint.R
@@ -1236,6 +1236,51 @@ describe("Resume Logic", {
 
       expect_equal(result$status, c("success", "pending"))
     })
+
+    it("carries stop_reason for terminal rows and clears it for resumable rows", {
+      task_grid <- data.frame(
+        task_id = c("t1", "t2", "t3"),
+        status = c("pending", "pending", "pending"),
+        stop_reason = c(NA_character_, NA_character_, NA_character_),
+        stringsAsFactors = FALSE
+      )
+
+      # Policy-stopped rows return to pending on resume and must not keep a
+      # stop reason; terminal rows keep whatever the checkpoint recorded.
+      checkpoint_grid <- data.frame(
+        task_id = c("t1", "t2", "t3"),
+        status = c("failed", "skipped", "skipped"),
+        stop_reason = c("max_errors", "adaptive_stop", "max_errors"),
+        stringsAsFactors = FALSE
+      )
+
+      result <- merge_task_grid_status(task_grid, checkpoint_grid)
+
+      expect_equal(result$status, c("failed", "pending", "pending"))
+      expect_equal(
+        result$stop_reason,
+        c("max_errors", NA_character_, NA_character_)
+      )
+    })
+
+    it("adds the stop_reason column when only the checkpoint grid has one", {
+      task_grid <- data.frame(
+        task_id = c("t1", "t2"),
+        status = c("pending", "pending"),
+        stringsAsFactors = FALSE
+      )
+
+      checkpoint_grid <- data.frame(
+        task_id = c("t1", "t2"),
+        status = c("success", "skipped"),
+        stop_reason = c(NA_character_, "max_errors"),
+        stringsAsFactors = FALSE
+      )
+
+      result <- merge_task_grid_status(task_grid, checkpoint_grid)
+
+      expect_equal(result$stop_reason, c(NA_character_, NA_character_))
+    })
   })
 
   describe("merge_results()", {

--- a/tests/testthat/test-lifecycle-integration.R
+++ b/tests/testthat/test-lifecycle-integration.R
@@ -350,6 +350,17 @@ test_that("resume error budget includes persisted failed outcomes", {
     as.integer(table(unchanged$summary$status)[c("failed", "skipped")]),
     c(1, 2)
   )
+  # The carried-over failure count exhausts the budget before any task runs,
+  # so the restored placeholders must be re-labeled as policy stops instead of
+  # staying pending with no recorded reason (#64).
+  expect_equal(
+    unchanged$task_grid$status,
+    c("failed", "skipped", "skipped")
+  )
+  expect_equal(
+    unchanged$task_grid$stop_reason,
+    c(NA_character_, "max_errors", "max_errors")
+  )
 
   raised_path <- file.path(withr::local_tempdir(), "raised-budget")
   run_simulation(

--- a/tests/testthat/test-runtime-ux.R
+++ b/tests/testthat/test-runtime-ux.R
@@ -339,6 +339,43 @@ describe("F7 end-of-run summary", {
     expect_match(resumed$text, "Results:", fixed = TRUE)
   })
 
+  it("reports the specific stop reason when a resume stops before executing", {
+    path <- withr::local_tempdir()
+    config <- simulation_config(
+      data_grid = data.frame(n = 20),
+      fit_grid = data.frame(model = "lm"),
+      data_generator = function(data_spec, task_ctx) {
+        stop("Intentional failure")
+      },
+      fitter = LinearRegressionFitter(n_draws = 20L),
+      metrics = list(),
+      n_replicates = 4L,
+      seed = 47L,
+      max_errors = 1L,
+      checkpoint_every = 1L,
+      result_path = file.path(path, "restopped")
+    )
+    .run_messages(config, resume = "never", progress = FALSE)
+
+    # Resuming with the unchanged budget stops before executing anything (the
+    # persisted failure already exhausts it). The summary must name the reason
+    # instead of falling back to the generic "stopped early", and the grid must
+    # re-label the restored placeholders as policy stops (#64).
+    restopped <- .run_messages(config, resume = "must", progress = FALSE)
+    expect_match(
+      restopped$text,
+      "Simulation stopped early \\(error budget exhausted\\): 0 succeeded, 1 failed, 3 of 4 tasks not run"
+    )
+    expect_false(grepl("(stopped early)", restopped$text, fixed = TRUE))
+    expect_equal(sum(restopped$result$task_grid$status == "skipped"), 3L)
+    expect_equal(
+      restopped$result$task_grid$stop_reason[
+        restopped$result$task_grid$status == "skipped"
+      ],
+      rep("max_errors", 3L)
+    )
+  })
+
   it("stays silent when verbose = FALSE", {
     path <- withr::local_tempdir()
     config <- simulation_config(


### PR DESCRIPTION
## Summary

Closes #64.

A resume that stops before executing any task — most commonly because the carried-over failure count already exhausts an unchanged `max_errors` budget — left restored policy-stop placeholders labeled `pending` with `stop_reason = NA` in the returned task grid, and the end-of-run summary (`print_run_summary()`) fell back to the generic "stopped early" reason instead of naming the policy that stopped the run. Diagnostic-only, not a correctness bug: a later resume still treated those tasks as resumable either way.

Two label-fidelity fixes, following the direction suggested in the issue:

- **`execute_tasks()` end-of-loop fill** (`R/simulate.R`): the fill previously re-marked only tasks whose `task_results` slot was `NULL`. Slots restored from `prior_task_results` are non-NULL, so restored placeholders survived with `pending` grid labels. The fill now treats a restored placeholder outcome (`status = "skipped"`) under a still-`pending` grid row as unexecuted and re-marks it `skipped` + the run's stop reason. Placeholders the batch loop marked inline for an adaptive stop (grid row already `skipped`) keep their more specific message.
- **`merge_task_grid_status()`** (`R/resume.R`): now carries a recorded `stop_reason` for merged terminal rows instead of dropping the column's values. Rows reset to `pending` stay `NA` there; the immediate-stop path re-marks them.

## Repro (from the issue)

4-replicate study, rep 1 fails, `max_errors = 1`, then resume with the unchanged budget:

| | before | after |
|---|---|---|
| resumed grid rows 2–4 | `pending` / `NA` | `skipped` / `max_errors` |
| end-of-run block | "stopped early" (generic fallback) | "error budget exhausted" |

## Tests

- `test-checkpoint.R`: `merge_task_grid_status()` carries `stop_reason` for terminal rows, clears it for resumable rows, and adds the column when only the checkpoint grid has one.
- `test-lifecycle-integration.R`: the unchanged-budget resume in "resume error budget includes persisted failed outcomes" now also asserts the grid labels (`skipped`/`max_errors`).
- `test-runtime-ux.R`: new case — a resume that stops before executing anything prints the specific reason and shows `skipped`/`max_errors` grid labels.

All touched files are in the fast tier; no new test files. Fast and core tiers pass locally, `air format`/`jarl check` clean, `R CMD check` matches the master warning baseline (known S7/codoc WARNING, #56), and `inst/benchmarks/checkpoint-scaling.R` integrity holds.

Out-of-scope follow-up filed separately: #65 (`meta.json`'s `n_pending` counts policy-stopped tasks as pending).