### PR TITLE
Consult supports_epred: warn instead of silently NA-degrading LOO-prediction metrics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,15 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
   mean.
 * Metric NA-degradation paths now emit schema-conformant fields (present
   with `NA` values) instead of dropping fields from the flattened summary.
+* `rmse_loo_metric()` and `r2_loo_metric()` now declare `needs =
+  c("loo", "epred")` and the `supports_epred` fitter capability is actually
+  consulted: `preflight()` includes `epred` in its capability vocabulary
+  (surfacing it in `unmet_needs` before a run), the worker warns once when
+  an epred-needing metric runs on an epred-incapable fitter, and
+  `build_loo_context()` only calls `predict_epred()` for fitters that
+  declare support. A `supports_loo = TRUE, supports_epred = FALSE` fitter
+  (e.g. a `CmdStanFitter()` without an `epred` generated quantity) no longer
+  produces silently all-NA LOO-prediction columns (#62).
 
 ## Fitters and errors
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,7 +59,9 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
   `build_loo_context()` only calls `predict_epred()` for fitters that
   declare support. A `supports_loo = TRUE, supports_epred = FALSE` fitter
   (e.g. a `CmdStanFitter()` without an `epred` generated quantity) no longer
-  produces silently all-NA LOO-prediction columns (#62).
+  produces silently all-NA LOO-prediction columns (#62). A `predict_epred()`
+  return with the wrong shape now degrades through the same warn-once NA
+  path instead of surfacing as a generic metric error inside `loo::E_loo()`.
 
 ## Fitters and errors
 

--- a/R/fitter.R
+++ b/R/fitter.R
@@ -138,6 +138,37 @@ validate_fitter_log_lik <- function(log_lik, n_obs) {
   invisible(log_lik)
 }
 
+# epred is consumed by loo::E_loo() against the PSIS object built from the
+# pointwise log-lik, so the two must share draws x observations dimensions;
+# the checks mirror validate_fitter_log_lik().
+validate_fitter_epred <- function(epred, n_draws, n_obs) {
+  if (
+    !is.matrix(epred) ||
+      !is.numeric(epred) ||
+      nrow(epred) != n_draws ||
+      ncol(epred) != n_obs
+  ) {
+    got <- if (is.matrix(epred)) {
+      paste(dim(epred), collapse = " x ")
+    } else {
+      paste(class(epred), collapse = "/")
+    }
+    stop(bayesim_contract_error(
+      paste0(
+        "predict_epred() must return a numeric S x N matrix aligned with ",
+        "log_lik_matrix() (expected ",
+        n_draws,
+        " x ",
+        n_obs,
+        ", got ",
+        got,
+        ")"
+      )
+    ))
+  }
+  invisible(epred)
+}
+
 # =============================================================================
 # S7 Generics for Fitter methods
 # =============================================================================

--- a/R/metric.R
+++ b/R/metric.R
@@ -11,7 +11,7 @@
 #' @param name Character identifier for the metric. Used as a prefix when
 #'   flattening metric output to column names.
 #' @param needs Character vector of required capabilities from the fitter.
-#'   Common values include "predictions", "log_lik", "loo". The metric
+#'   Common values include "predictions", "log_lik", "loo", "epred". The metric
 #'   will only receive these values in the context if the fitter provides
 #'   them.
 #' @param required Logical indicating whether metric failure causes task

--- a/R/metric.R
+++ b/R/metric.R
@@ -13,7 +13,9 @@
 #' @param needs Character vector of required capabilities from the fitter.
 #'   Common values include "predictions", "log_lik", "loo", "epred". The metric
 #'   will only receive these values in the context if the fitter provides
-#'   them.
+#'   them. `epred` is delivered as `context$loo_epred` inside the LOO context,
+#'   so declare it alongside `"loo"` (as `rmse_loo_metric()` does); a metric
+#'   declaring `needs = "epred"` alone never receives the matrix.
 #' @param required Logical indicating whether metric failure causes task
 #'   failure. If TRUE, an error in computing this metric will propagate and
 #'   fail the entire task. If FALSE (default), metric failure results in

--- a/R/metrics-extended.R
+++ b/R/metrics-extended.R
@@ -665,7 +665,10 @@ RmseLooMetric <- S7::new_class(
       default = "rmse_loo",
       validator = validate_metric_name
     ),
-    needs = S7::new_property(S7::class_character, default = "loo"),
+    needs = S7::new_property(
+      S7::class_character,
+      default = c("loo", "epred")
+    ),
     required = S7::new_property(S7::class_logical, default = FALSE),
     schema = S7::new_property(
       S7::class_list,
@@ -757,7 +760,10 @@ R2LooMetric <- S7::new_class(
       default = "r2_loo",
       validator = validate_metric_name
     ),
-    needs = S7::new_property(S7::class_character, default = "loo"),
+    needs = S7::new_property(
+      S7::class_character,
+      default = c("loo", "epred")
+    ),
     required = S7::new_property(S7::class_logical, default = FALSE),
     schema = S7::new_property(
       S7::class_list,
@@ -779,7 +785,7 @@ R2LooMetric <- S7::new_class(
 r2_loo_metric <- function(name = "r2_loo") {
   R2LooMetric(
     name = name,
-    needs = "loo",
+    needs = c("loo", "epred"),
     required = FALSE,
     schema = list(
       value = list(role = "estimate", aggregation = "mean", mcse = "sd"),

--- a/R/runtime-ux.R
+++ b/R/runtime-ux.R
@@ -48,7 +48,8 @@ preflight <- function(config, pilot = FALSE, condensed = FALSE) {
     c(
       if (isTRUE(fitter@supports_predictions)) "predictions",
       if (isTRUE(fitter@supports_log_lik)) "log_lik",
-      if (isTRUE(fitter@supports_loo)) "loo"
+      if (isTRUE(fitter@supports_loo)) "loo",
+      if (isTRUE(fitter@supports_epred)) "epred"
     )
   } else {
     character()

--- a/R/worker.R
+++ b/R/worker.R
@@ -583,6 +583,10 @@ build_metric_context <- function(
       # A fitter that declares epred support but produced no matrix at run
       # time is an anomaly like a failing predict_fit(); the unsupported-
       # capability warning above did not fire, so explain the NA degradation.
+      # Deliberately generic: build_loo_context() also returns epred = NULL
+      # when the train-set log-lik matrix failed (predict_epred() is then
+      # never attempted), so naming predict_epred() would misattribute the
+      # cause.
       needs_epred <- "epred" %in% all_needs
       if (
         needs_epred && isTRUE(fitter@supports_epred) && is.null(loo_ctx$epred)
@@ -590,7 +594,7 @@ build_metric_context <- function(
         .warn_once(
           "loo_epred_failed",
           paste0(
-            "predict_epred() failed or returned NULL; ",
+            "epred matrix unavailable from the LOO context; ",
             "epred-based LOO metrics (rmse_loo, r2_loo) will be NA."
           )
         )
@@ -656,12 +660,18 @@ build_loo_context <- function(fitter, fit_result) {
 
   # Posterior expectation predictions (mu, no noise). Required for r2_loo;
   # rmse_loo also degrades to NA when epred is absent. Gated on the declared
-  # capability: fitters with supports_epred = FALSE skip the call entirely.
+  # capability: fitters with supports_epred = FALSE skip the call entirely. A
+  # wrong-shaped return degrades to NULL here (warn-once at the seam) instead
+  # of dying as a generic metric error inside loo::E_loo().
   epred <- if (!isTRUE(fitter@supports_epred)) {
     NULL
   } else {
     tryCatch(
-      predict_epred(fitter, fit_result),
+      {
+        epred <- predict_epred(fitter, fit_result)
+        validate_fitter_epred(epred, n_draws = nrow(ll), n_obs = ncol(ll))
+        epred
+      },
       error = function(e) NULL
     )
   }

--- a/R/worker.R
+++ b/R/worker.R
@@ -483,6 +483,13 @@ build_metric_context <- function(
       "Metric requires loo but fitter does not support it"
     )
   }
+  if ("epred" %in% all_needs && !fitter@supports_epred) {
+    .warn_once(
+      "unsupported_capability.epred",
+      "Metric requires epred but fitter does not support it",
+      i = "epred-based LOO metrics (rmse_loo, r2_loo) will be NA."
+    )
+  }
 
   # Predictions and pointwise log-lik are evaluated on the test set when one
   # exists (all consuming metrics compare against the test response); NULL
@@ -573,6 +580,21 @@ build_metric_context <- function(
       context$loo_psis <- loo_ctx$psis
       context$loo_psis_ll <- loo_ctx$log_lik
       context$loo_epred <- loo_ctx$epred
+      # A fitter that declares epred support but produced no matrix at run
+      # time is an anomaly like a failing predict_fit(); the unsupported-
+      # capability warning above did not fire, so explain the NA degradation.
+      needs_epred <- "epred" %in% all_needs
+      if (
+        needs_epred && isTRUE(fitter@supports_epred) && is.null(loo_ctx$epred)
+      ) {
+        .warn_once(
+          "loo_epred_failed",
+          paste0(
+            "predict_epred() failed or returned NULL; ",
+            "epred-based LOO metrics (rmse_loo, r2_loo) will be NA."
+          )
+        )
+      }
     }
   }
 
@@ -595,8 +617,9 @@ build_metric_context <- function(
 #' accurate.
 #'
 #' epred must be the posterior expectation (mu, no observation noise); for brms
-#' this is `brms::posterior_epred`. The Fitter must expose this via
-#' `predict_epred()`; fitters that cannot return NULL (the metrics then NA).
+#' this is `brms::posterior_epred`. Only fitters with `supports_epred = TRUE`
+#' are asked for it via `predict_epred()`; otherwise epred is NULL and the
+#' consuming metrics (r2_loo, rmse_loo) degrade to NA.
 #'
 #' @return A list with elements `loo`, `psis`, `log_lik`, `epred`, or NULL on
 #'   failure. `psis`/`log_lik`/`epred` may be individually NULL if unavailable.
@@ -632,11 +655,16 @@ build_loo_context <- function(fitter, fit_result) {
   }
 
   # Posterior expectation predictions (mu, no noise). Required for r2_loo;
-  # rmse_loo also degrades to NA when epred is absent.
-  epred <- tryCatch(
-    predict_epred(fitter, fit_result),
-    error = function(e) NULL
-  )
+  # rmse_loo also degrades to NA when epred is absent. Gated on the declared
+  # capability: fitters with supports_epred = FALSE skip the call entirely.
+  epred <- if (!isTRUE(fitter@supports_epred)) {
+    NULL
+  } else {
+    tryCatch(
+      predict_epred(fitter, fit_result),
+      error = function(e) NULL
+    )
+  }
 
   list(
     loo = loo_result,

--- a/man/Metric.Rd
+++ b/man/Metric.Rd
@@ -17,7 +17,7 @@ Metric(
 flattening metric output to column names.}
 
 \item{needs}{Character vector of required capabilities from the fitter.
-Common values include "predictions", "log_lik", "loo". The metric
+Common values include "predictions", "log_lik", "loo", "epred". The metric
 will only receive these values in the context if the fitter provides
 them.}
 

--- a/man/Metric.Rd
+++ b/man/Metric.Rd
@@ -19,7 +19,9 @@ flattening metric output to column names.}
 \item{needs}{Character vector of required capabilities from the fitter.
 Common values include "predictions", "log_lik", "loo", "epred". The metric
 will only receive these values in the context if the fitter provides
-them.}
+them. \code{epred} is delivered as \code{context$loo_epred} inside the LOO context,
+so declare it alongside \code{"loo"} (as \code{rmse_loo_metric()} does); a metric
+declaring \code{needs = "epred"} alone never receives the matrix.}
 
 \item{required}{Logical indicating whether metric failure causes task
 failure. If TRUE, an error in computing this metric will propagate and

--- a/man/R2LooMetric.Rd
+++ b/man/R2LooMetric.Rd
@@ -7,7 +7,7 @@
 \usage{
 R2LooMetric(
   name = "r2_loo",
-  needs = "loo",
+  needs = c("loo", "epred"),
   required = FALSE,
   summary_type = "mean",
   schema = list(value = list(role = "estimate", aggregation = "mean", mcse = "sd"), elpd

--- a/man/RmseLooMetric.Rd
+++ b/man/RmseLooMetric.Rd
@@ -7,7 +7,7 @@
 \usage{
 RmseLooMetric(
   name = "rmse_loo",
-  needs = "loo",
+  needs = c("loo", "epred"),
   required = FALSE,
   summary_type = "mean",
   schema = list(value = list(role = "estimate", aggregation = "mean", mcse = "sd"), elpd

--- a/man/build_loo_context.Rd
+++ b/man/build_loo_context.Rd
@@ -26,7 +26,8 @@ structure is unavailable, which is mathematically valid but slightly less
 accurate.
 
 epred must be the posterior expectation (mu, no observation noise); for brms
-this is \code{brms::posterior_epred}. The Fitter must expose this via
-\code{predict_epred()}; fitters that cannot return NULL (the metrics then NA).
+this is \code{brms::posterior_epred}. Only fitters with \code{supports_epred = TRUE}
+are asked for it via \code{predict_epred()}; otherwise epred is NULL and the
+consuming metrics (r2_loo, rmse_loo) degrade to NA.
 }
 \keyword{internal}

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -879,6 +879,92 @@ describe("Worker", {
       # Should not have predictions since fitter doesn't support it
       expect_false("predictions" %in% names(context))
     })
+
+    it("warns once when a metric needs epred the fitter does not support", {
+      # MockFitter supports loo but inherits supports_epred = FALSE — the
+      # silent-NA shape from #62: r2_loo/rmse_loo must explain their
+      # degradation instead of returning all-NA columns.
+      bayesim:::.reset_warn_once()
+      fitter <- MockFitter()
+      data_bundle <- valid_data_bundle()
+
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- NULL
+      expect_warning(
+        context <- build_metric_context(
+          fit_result,
+          fitter,
+          data_bundle,
+          list(r2_loo_metric())
+        ),
+        "Metric requires epred but fitter does not support it"
+      )
+      # The loo summary is still built (loo is supported); only the epred part
+      # of the LOO context is absent.
+      expect_false(is.null(context$loo))
+      expect_true(is.null(context$loo_epred))
+
+      # Warn once per run, not per task.
+      expect_silent(
+        build_metric_context(
+          fit_result,
+          fitter,
+          data_bundle,
+          list(r2_loo_metric())
+        )
+      )
+    })
+
+    it("warns once when an epred-supporting fitter fails to produce epred", {
+      # supports_epred = TRUE but predict_epred() errors at run time: the
+      # unsupported-capability warning must not fire; the LOO-context seam
+      # explains the NA degradation instead (#62). S7 keeps the parent's
+      # property default when a subclass redeclares it, so set the flag on
+      # the instance.
+      bayesim:::.reset_warn_once()
+      BrokenEpredFitter <- S7::new_class(
+        "BrokenEpredFitter",
+        parent = MockFitter
+      )
+      S7::method(predict_epred, BrokenEpredFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        stop("boom")
+      }
+      fitter <- BrokenEpredFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- NULL
+      expect_warning(
+        context <- build_metric_context(
+          fit_result,
+          fitter,
+          data_bundle,
+          list(r2_loo_metric())
+        ),
+        "predict_epred\\(\\) failed or returned NULL"
+      )
+      expect_false(is.null(context$loo))
+      expect_true(is.null(context$loo_epred))
+    })
   })
 
   describe("compute_all_metrics()", {

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -960,10 +960,52 @@ describe("Worker", {
           data_bundle,
           list(r2_loo_metric())
         ),
-        "predict_epred\\(\\) failed or returned NULL"
+        "epred matrix unavailable"
       )
       expect_false(is.null(context$loo))
       expect_true(is.null(context$loo_epred))
+    })
+
+    it("degrades a wrong-shaped predict_epred return to the warn-once path", {
+      # A vector or dimension-mismatched matrix would otherwise bypass the
+      # seam warning and die as a generic metric error inside loo::E_loo().
+      bayesim:::.reset_warn_once()
+      BadShapeEpredFitter <- S7::new_class(
+        "BadShapeEpredFitter",
+        parent = MockFitter
+      )
+      S7::method(predict_epred, BadShapeEpredFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(10), nrow = 5, ncol = 2)
+      }
+      fitter <- BadShapeEpredFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- NULL
+      expect_warning(
+        context <- build_metric_context(
+          fit_result,
+          fitter,
+          data_bundle,
+          list(r2_loo_metric())
+        ),
+        "epred matrix unavailable"
+      )
+      # The malformed matrix must not reach the metric context.
+      expect_true(is.null(context$loo_epred))
+      expect_false(is.null(context$loo))
     })
   })
 

--- a/tests/testthat/test-metrics-extended.R
+++ b/tests/testthat/test-metrics-extended.R
@@ -454,6 +454,16 @@ describe("M5 extended metrics", {
     expect_true(is.na(out$value))
   })
 
+  it("rmse_loo / r2_loo declare the epred capability need (#62)", {
+    # Both consume context$loo_epred; declaring it in `needs` lets preflight()
+    # and build_metric_context() warn about epred-incapable fitters instead of
+    # silently NA-degrading. elpd_loo only reads the loo summary, so it must
+    # keep declaring "loo" alone.
+    expect_equal(rmse_loo_metric()@needs, c("loo", "epred"))
+    expect_equal(r2_loo_metric()@needs, c("loo", "epred"))
+    expect_equal(elpd_loo_metric()@needs, "loo")
+  })
+
   it("elpd_test_metric computes log-sum-exp elpd on log_lik", {
     ll <- matrix(c(-1, -2, -1.5, -2.5), nrow = 2) # 2 draws x 2 obs
     fx <- make_fixture(log_lik = ll, test = data.frame(y = c(1, 2)))

--- a/tests/testthat/test-runtime-ux.R
+++ b/tests/testthat/test-runtime-ux.R
@@ -44,6 +44,40 @@ describe("F1 preflight", {
     expect_invisible(preflight(config, condensed = TRUE))
   })
 
+  it("surfaces epred as an unmet need for epred-incapable fitters (#62)", {
+    # MockFitter declares supports_loo = TRUE but inherits the Fitter default
+    # supports_epred = FALSE: without epred in the capability vocabulary,
+    # preflight reported "all needs satisfied" while r2_loo NA-degraded.
+    config <- simulation_config(
+      data_grid = data.frame(n = 20),
+      fit_grid = data.frame(model = "mock"),
+      data_generator = .gen,
+      fitter = MockFitter(),
+      metrics = list(r2_loo_metric()),
+      n_replicates = 1L,
+      seed = 1L
+    )
+    info <- suppressMessages(suppressWarnings(preflight(config)))
+    expect_equal(info$fitter_capabilities, c("predictions", "log_lik", "loo"))
+    expect_equal(info$metric_needs, c("loo", "epred"))
+    expect_equal(info$unmet_needs, "epred")
+  })
+
+  it("reports no unmet epred need when the fitter supports it", {
+    config <- simulation_config(
+      data_grid = data.frame(n = 20),
+      fit_grid = data.frame(model = "lm"),
+      data_generator = .gen,
+      fitter = LinearRegressionFitter(n_draws = 50L),
+      metrics = list(r2_loo_metric()),
+      n_replicates = 1L,
+      seed = 1L
+    )
+    info <- suppressMessages(preflight(config))
+    expect_true("epred" %in% info$fitter_capabilities)
+    expect_equal(info$unmet_needs, character())
+  })
+
   it("counts distinct brms model specs rather than fit-grid rows", {
     skip_if_not(requireNamespace("brms", quietly = TRUE))
     grid <- data.frame(model = c("a", "a-copy"))


### PR DESCRIPTION
Closes #62.

## Problem

`supports_epred` exists on the Fitter contract (validated by `validate_fitter()`), but nothing consulted it. A fitter with `supports_loo = TRUE, supports_epred = FALSE` (e.g. a custom `CmdStanFitter` without an `epred` generated quantity) passed preflight with "all needs satisfied", then `r2_loo`/`rmse_loo` returned all-`NA` columns with no explanation — unlike the symmetric `predictions`/`log_lik`/`loo` paths, which each emit a warn-once.

Repro before this PR (`MockFitter` supports loo but inherits `supports_epred = FALSE`):

```
preflight(config)  → unmet_needs: (empty)   # "all satisfied"
run_simulation(...) → r2_loo__value = NA    # no warning anywhere
```

## Changes

- **Preflight** (`R/runtime-ux.R`): `epred` joins the capability vocabulary built from the fitter's `supports_*` flags, so it can appear in `unmet_needs` and fire the existing unmet-needs warning (both full and condensed mode).
- **Metric declarations** (`R/metrics-extended.R`): `RmseLooMetric`/`R2LooMetric` now declare `needs = c("loo", "epred")` — their `compute_metric()` consumes `context$loo_epred`. `elpd_loo` keeps `needs = "loo"` (it only reads the summary).
- **Worker seam** (`R/worker.R`):
  - `build_metric_context()` warns once (`unsupported_capability.epred`) when an epred-needing metric runs on an epred-incapable fitter, mirroring the existing three capability branches.
  - Warns once at the LOO-context seam when a fitter that *declares* epred support produces no matrix at run time (`predict_epred()` failed or returned NULL), mirroring `log_lik_failed`/`loo_build_failed`.
  - `build_loo_context()` only calls `predict_epred()` for fitters that declare `supports_epred = TRUE`.
- **Docs**: `Metric`'s `needs` parameter documents `epred`; `build_loo_context`'s contract doc updated; man pages regenerated; NEWS entry added.

After this PR the same repro warns at preflight ("unmet needs: epred") and once per run ("Metric requires epred but fitter does not support it / epred-based LOO metrics (rmse_loo, r2_loo) will be NA"), while `elpd_loo` still computes from the LOO summary.

## Tests

- `test-runtime-ux.R`: preflight reports `epred` in `unmet_needs` for `MockFitter` + `r2_loo_metric()`, and reports nothing unmet for an epred-capable fitter.
- `test-engine.R`: `build_metric_context()` warns once (not per task) for the epred-incapable case with the LOO summary still built; a `supports_epred = TRUE` fitter whose `predict_epred()` errors triggers the seam warning.
- `test-metrics-extended.R`: the two LOO-prediction metrics declare `c("loo", "epred")`; `elpd_loo` still declares `"loo"` only.

## Verification

- Full core test suite: FAIL 0 | WARN 11 | SKIP 6 | PASS 1354 (baseline at HEAD: WARN 11, PASS 1339 — no new warnings, +15 tests).
- `air format . --check` and `jarl check .` clean.
- `R CMD check`: 0 errors, 1 warning (the documented S7/codoc false positive, see CONTRIBUTING.md), 0 notes; no new codoc mismatch from the changed constructor defaults.
- Backend-tier tests use `BrmsFitter` (`supports_epred = TRUE`), so the `needs` change does not affect them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - LOO RMSE and R² metrics now require expected prediction support.
  - Preflight checks identify whether expected predictions are available.
  - Compatible fitters use expected predictions for LOO calculations.

- **Bug Fixes**
  - Unsupported or failed expected predictions no longer produce misleading all-`NA` LOO results.
  - Clear warnings are shown when required prediction support is unavailable.

- **Documentation**
  - Updated metric and LOO documentation to describe expected prediction requirements and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->