### PR TITLE
Build epred for metrics declaring needs = "epred" without "loo"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,13 +66,14 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
   `context$loo_epred`: the matrix used to be built only inside the LOO
   context, so an epred-only metric silently computed on a missing context
   element and NA-degraded with no explanation. epred is now built directly
-  via `predict_epred()` whenever the LOO context is not built (no `"loo"`
-  need, unsupported LOO, or a failed LOO build), with its own warn-once NA
-  path when `predict_epred()` fails or returns a wrong-shaped matrix (#68).
-  When the context carries `loo_epred` without a LOO summary, an exact NULL
-  `loo` binding is pinned (and the built-in loo metrics read `context[["loo"]]`)
-  so `$` partial matching can no longer hand a metric the epred matrix when
-  it asked for `context$loo`.
+  via `predict_epred()` whenever the LOO context did not deliver it and
+  never attempted it (no `"loo"` need, unsupported or failed LOO build, or
+  a LOO context that bailed at the train-set log-lik matrix), with its own
+  warn-once NA path when `predict_epred()` fails or returns a wrong-shaped
+  matrix. When the context carries `loo_epred` without a LOO summary, an
+  exact NULL `loo` binding is pinned (and the built-in loo metrics read
+  `context[["loo"]]`) so `$` partial matching can no longer hand a metric
+  the epred matrix when it asked for `context$loo` (#68).
 
 ## Fitters and errors
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,10 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
   via `predict_epred()` whenever the LOO context is not built (no `"loo"`
   need, unsupported LOO, or a failed LOO build), with its own warn-once NA
   path when `predict_epred()` fails or returns a wrong-shaped matrix (#68).
+  When the context carries `loo_epred` without a LOO summary, an exact NULL
+  `loo` binding is pinned (and the built-in loo metrics read `context[["loo"]]`)
+  so `$` partial matching can no longer hand a metric the epred matrix when
+  it asked for `context$loo`.
 
 ## Fitters and errors
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,13 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
   produces silently all-NA LOO-prediction columns (#62). A `predict_epred()`
   return with the wrong shape now degrades through the same warn-once NA
   path instead of surfacing as a generic metric error inside `loo::E_loo()`.
+* Metrics declaring `needs = "epred"` without `"loo"` now actually receive
+  `context$loo_epred`: the matrix used to be built only inside the LOO
+  context, so an epred-only metric silently computed on a missing context
+  element and NA-degraded with no explanation. epred is now built directly
+  via `predict_epred()` whenever the LOO context is not built (no `"loo"`
+  need, unsupported LOO, or a failed LOO build), with its own warn-once NA
+  path when `predict_epred()` fails or returns a wrong-shaped matrix (#68).
 
 ## Fitters and errors
 

--- a/R/fitter.R
+++ b/R/fitter.R
@@ -140,12 +140,15 @@ validate_fitter_log_lik <- function(log_lik, n_obs) {
 
 # epred is consumed by loo::E_loo() against the PSIS object built from the
 # pointwise log-lik, so the two must share draws x observations dimensions;
-# the checks mirror validate_fitter_log_lik().
+# the checks mirror validate_fitter_log_lik(). n_draws may be NULL when no
+# paired log-lik matrix exists (epred built outside the LOO context); then
+# only the observation count and a non-empty draws dimension are checked.
 validate_fitter_epred <- function(epred, n_draws, n_obs) {
   if (
     !is.matrix(epred) ||
       !is.numeric(epred) ||
-      nrow(epred) != n_draws ||
+      (!is.null(n_draws) && nrow(epred) != n_draws) ||
+      (is.null(n_draws) && nrow(epred) < 1L) ||
       ncol(epred) != n_obs
   ) {
     got <- if (is.matrix(epred)) {
@@ -153,11 +156,13 @@ validate_fitter_epred <- function(epred, n_draws, n_obs) {
     } else {
       paste(class(epred), collapse = "/")
     }
+    expected_draws <- if (is.null(n_draws)) "S" else n_draws
     stop(bayesim_contract_error(
       paste0(
-        "predict_epred() must return a numeric S x N matrix aligned with ",
-        "log_lik_matrix() (expected ",
-        n_draws,
+        "predict_epred() must return a numeric S x N matrix",
+        if (is.null(n_draws)) "" else " aligned with log_lik_matrix()",
+        " (expected ",
+        expected_draws,
         " x ",
         n_obs,
         ", got ",

--- a/R/metric.R
+++ b/R/metric.R
@@ -13,9 +13,10 @@
 #' @param needs Character vector of required capabilities from the fitter.
 #'   Common values include "predictions", "log_lik", "loo", "epred". The metric
 #'   will only receive these values in the context if the fitter provides
-#'   them. `epred` is delivered as `context$loo_epred` inside the LOO context,
-#'   so declare it alongside `"loo"` (as `rmse_loo_metric()` does); a metric
-#'   declaring `needs = "epred"` alone never receives the matrix.
+#'   them. `epred` is delivered as `context$loo_epred`, a draws x observations
+#'   matrix computed on the training set; it is delivered whether or not
+#'   `"loo"` is also declared — without `"loo"` the matrix is built directly
+#'   instead of through the LOO context.
 #' @param required Logical indicating whether metric failure causes task
 #'   failure. If TRUE, an error in computing this metric will propagate and
 #'   fail the entire task. If FALSE (default), metric failure results in

--- a/R/metrics-extended.R
+++ b/R/metrics-extended.R
@@ -629,7 +629,9 @@ S7::method(compute_metric, ElpdLooMetric) <- function(
   context,
   task_ctx
 ) {
-  loo <- context$loo
+  # Exact [[ ]] access: $loo would partial-match loo_epred when the context
+  # carries an epred matrix without a LOO summary (#68).
+  loo <- context[["loo"]]
   if (is.null(loo)) {
     return(list(
       elpd = NA_real_,
@@ -703,7 +705,9 @@ S7::method(compute_metric, RmseLooMetric) <- function(
   context,
   task_ctx
 ) {
-  loo <- context$loo
+  # Exact [[ ]] access for loo: $loo would partial-match loo_epred when the
+  # context carries an epred matrix without a LOO summary (#68).
+  loo <- context[["loo"]]
   psis_obj <- context$loo_psis
   ll <- context$loo_psis_ll
   ppred <- context$loo_epred
@@ -802,7 +806,9 @@ S7::method(compute_metric, R2LooMetric) <- function(
   context,
   task_ctx
 ) {
-  loo <- context$loo
+  # Exact [[ ]] access for loo: $loo would partial-match loo_epred when the
+  # context carries an epred matrix without a LOO summary (#68).
+  loo <- context[["loo"]]
   psis_obj <- context$loo_psis
   ll <- context$loo_psis_ll
   epred <- context$loo_epred

--- a/R/worker.R
+++ b/R/worker.R
@@ -580,32 +580,13 @@ build_metric_context <- function(
       }
     )
     if (!is.null(loo_ctx)) {
-      context$loo <- loo_ctx$loo
       # F3: PSIS-based prediction machinery for rmse_loo / r2_loo. Built once
       # here so both metrics share it. May be absent (NULL) if the fitter does
       # not provide epred/log_lik or the build failed.
+      context$loo <- loo_ctx$loo
       context$loo_psis <- loo_ctx$psis
       context$loo_psis_ll <- loo_ctx$log_lik
       context$loo_epred <- loo_ctx$epred
-      # A fitter that declares epred support but produced no matrix at run
-      # time is an anomaly like a failing predict_fit(); the unsupported-
-      # capability warning above did not fire, so explain the NA degradation.
-      # Deliberately generic: build_loo_context() also returns epred = NULL
-      # when the train-set log-lik matrix failed (predict_epred() is then
-      # never attempted), so naming predict_epred() would misattribute the
-      # cause.
-      needs_epred <- "epred" %in% all_needs
-      if (
-        needs_epred && isTRUE(fitter@supports_epred) && is.null(loo_ctx$epred)
-      ) {
-        .warn_once(
-          "loo_epred_failed",
-          paste0(
-            "epred matrix unavailable from the LOO context; ",
-            "epred-based LOO metrics (rmse_loo, r2_loo) will be NA."
-          )
-        )
-      }
     }
   }
 
@@ -613,15 +594,26 @@ build_metric_context <- function(
   # only inside the LOO branch above — a metric declaring needs = "epred"
   # without "loo" (or on a fitter without LOO support) never received
   # context$loo_epred and silently NA-degraded with no warn-once explaining
-  # it. Build the matrix directly whenever the LOO branch did not, so the
-  # declared capability is honored like any other.
-  if ("epred" %in% all_needs && is.null(loo_ctx)) {
-    # Pin an exact NULL "loo" binding when a metric asked for "loo": $loo
-    # would otherwise partial-match the loo_epred matrix below and hand a
-    # $-reading metric (elpd_loo) the matrix instead of NULL.
-    # context["loo"] <- list(NULL) creates the element; $loo <- NULL would
-    # not.
-    if ("loo" %in% all_needs) {
+  # it. Build the matrix directly whenever it is still missing and the LOO
+  # context never attempted it:
+  # - the LOO context was not built at all (no "loo" need, unsupported LOO,
+  #   or a failed build), or
+  # - it bailed before epred (train-set log-lik failure).
+  # predict_epred() is deliberately not retried when the LOO context already
+  # attempted it and failed; that failure is explained by the warn-once
+  # below.
+  if (
+    "epred" %in%
+      all_needs &&
+      is.null(context[["loo_epred"]]) &&
+      (is.null(loo_ctx) || !isTRUE(loo_ctx$epred_attempted))
+  ) {
+    # Pin an exact NULL "loo" binding when a metric asked for "loo" but the
+    # LOO context was not built: $loo would otherwise partial-match the
+    # loo_epred matrix below and hand a $-reading metric (elpd_loo) the
+    # matrix instead of NULL. context["loo"] <- list(NULL) creates the
+    # element; $loo <- NULL would not.
+    if ("loo" %in% all_needs && is.null(loo_ctx)) {
       context["loo"] <- list(NULL)
     }
     context$loo_epred <- if (!isTRUE(fitter@supports_epred)) {
@@ -630,7 +622,8 @@ build_metric_context <- function(
       tryCatch(
         {
           # epred is a training-set quantity (LOO is in-sample by
-          # construction); no log-lik matrix exists to align draws against.
+          # construction); outside a complete LOO context there is no
+          # log-lik matrix to align draws against.
           epred <- predict_epred(fitter, fit_result)
           validate_fitter_epred(
             epred,
@@ -652,6 +645,29 @@ build_metric_context <- function(
         }
       )
     }
+  }
+
+  # A fitter that declares epred support but produced no matrix at run
+  # time is an anomaly like a failing predict_fit(); the unsupported-
+  # capability warning above did not fire, so explain the NA degradation.
+  # Only the attempted-and-failed-inside-the-LOO-context case reaches this:
+  # every other no-matrix shape was either built (or warned) by the direct
+  # branch above.
+  if (
+    "epred" %in%
+      all_needs &&
+      isTRUE(fitter@supports_epred) &&
+      is.null(context[["loo_epred"]]) &&
+      !is.null(loo_ctx) &&
+      isTRUE(loo_ctx$epred_attempted)
+  ) {
+    .warn_once(
+      "loo_epred_failed",
+      paste0(
+        "epred matrix unavailable from the LOO context; ",
+        "epred-based LOO metrics (rmse_loo, r2_loo) will be NA."
+      )
+    )
   }
 
   context
@@ -677,8 +693,12 @@ build_metric_context <- function(
 #' are asked for it via `predict_epred()`; otherwise epred is NULL and the
 #' consuming metrics (r2_loo, rmse_loo) degrade to NA.
 #'
-#' @return A list with elements `loo`, `psis`, `log_lik`, `epred`, or NULL on
-#'   failure. `psis`/`log_lik`/`epred` may be individually NULL if unavailable.
+#' @return A list with elements `loo`, `psis`, `log_lik`, `epred`, and
+#'   `epred_attempted` (logical; whether `predict_epred()` was called), or
+#'   NULL on failure. `psis`/`log_lik`/`epred` may be individually NULL if
+#'   unavailable; when the train-set log-lik matrix fails the function bails
+#'   with `epred_attempted = FALSE` so the caller can still build epred
+#'   directly (it does not depend on the log-lik).
 #' @keywords internal
 build_loo_context <- function(fitter, fit_result) {
   loo_result <- loo_fit(fitter, fit_result)
@@ -689,7 +709,13 @@ build_loo_context <- function(fitter, fit_result) {
   # Pointwise log-likelihood matrix (S x N, draws x observations).
   ll <- tryCatch(log_lik_matrix(fitter, fit_result), error = function(e) NULL)
   if (!is.matrix(ll)) {
-    return(list(loo = loo_result, psis = NULL, log_lik = NULL, epred = NULL))
+    return(list(
+      loo = loo_result,
+      psis = NULL,
+      log_lik = NULL,
+      epred = NULL,
+      epred_attempted = FALSE
+    ))
   }
 
   # Per-observation relative-efficiency via chain structure.
@@ -732,7 +758,8 @@ build_loo_context <- function(fitter, fit_result) {
     loo = loo_result,
     psis = psis_obj,
     log_lik = ll,
-    epred = epred
+    epred = epred,
+    epred_attempted = isTRUE(fitter@supports_epred)
   )
 }
 

--- a/R/worker.R
+++ b/R/worker.R
@@ -423,6 +423,9 @@ run_task <- function(
 #'     \item `predictions`: Prediction results from the fitter
 #'     \item `log_lik`: Pointwise log-likelihood matrix (S x N)
 #'     \item `loo`: LOO-CV results
+#'     \item `loo_psis`, `loo_psis_ll`, `loo_epred`: PSIS object, pointwise
+#'       log-lik, and posterior-expectation predictions backing the LOO
+#'       prediction metrics
 #'   }
 #'
 #' @details
@@ -435,7 +438,10 @@ run_task <- function(
 #' when `data_bundle$test` is present, otherwise on the training set. Every
 #' built-in metric that consumes them (`pred_*`, `elpd_test`, `r2_test`) compares against the test response, so the predictions must be
 #' for the test rows. The LOO context is always built on the training set —
-#' leave-one-out is in-sample by construction.
+#' leave-one-out is in-sample by construction. `loo_epred` is likewise a
+#' training-set matrix; when no metric needs `"loo"` (or the fitter lacks LOO
+#' support) it is built directly via [predict_epred()] rather than through
+#' the LOO context, so declaring `needs = "epred"` alone still delivers it.
 #'
 #' @keywords internal
 build_metric_context <- function(
@@ -560,6 +566,7 @@ build_metric_context <- function(
     )
   }
 
+  loo_ctx <- NULL
   if ("loo" %in% all_needs && fitter@supports_loo) {
     loo_ctx <- tryCatch(
       build_loo_context(fitter, fit_result),
@@ -599,6 +606,43 @@ build_metric_context <- function(
           )
         )
       }
+    }
+  }
+
+  # #68: epred does not depend on the LOO machinery, but it used to be built
+  # only inside the LOO branch above — a metric declaring needs = "epred"
+  # without "loo" (or on a fitter without LOO support) never received
+  # context$loo_epred and silently NA-degraded with no warn-once explaining
+  # it. Build the matrix directly whenever the LOO branch did not, so the
+  # declared capability is honored like any other.
+  if ("epred" %in% all_needs && is.null(loo_ctx)) {
+    context$loo_epred <- if (!isTRUE(fitter@supports_epred)) {
+      NULL # the unsupported_capability.epred warning above covers this
+    } else {
+      tryCatch(
+        {
+          # epred is a training-set quantity (LOO is in-sample by
+          # construction); no log-lik matrix exists to align draws against.
+          epred <- predict_epred(fitter, fit_result)
+          validate_fitter_epred(
+            epred,
+            n_draws = NULL,
+            n_obs = nrow(data_bundle$train)
+          )
+          epred
+        },
+        error = function(e) {
+          # No is_fatal_error() re-stop: a wrong-shaped predict_epred() return
+          # raises a contract error and must degrade through this warn-once
+          # exactly as it does when built via the LOO context.
+          .warn_once(
+            "epred_build_failed",
+            "predict_epred() failed; epred-based metrics will be NA.",
+            i = conditionMessage(e)
+          )
+          NULL
+        }
+      )
     }
   }
 

--- a/R/worker.R
+++ b/R/worker.R
@@ -616,6 +616,14 @@ build_metric_context <- function(
   # it. Build the matrix directly whenever the LOO branch did not, so the
   # declared capability is honored like any other.
   if ("epred" %in% all_needs && is.null(loo_ctx)) {
+    # Pin an exact NULL "loo" binding when a metric asked for "loo": $loo
+    # would otherwise partial-match the loo_epred matrix below and hand a
+    # $-reading metric (elpd_loo) the matrix instead of NULL.
+    # context["loo"] <- list(NULL) creates the element; $loo <- NULL would
+    # not.
+    if ("loo" %in% all_needs) {
+      context["loo"] <- list(NULL)
+    }
     context$loo_epred <- if (!isTRUE(fitter@supports_epred)) {
       NULL # the unsupported_capability.epred warning above covers this
     } else {

--- a/man/Metric.Rd
+++ b/man/Metric.Rd
@@ -19,9 +19,10 @@ flattening metric output to column names.}
 \item{needs}{Character vector of required capabilities from the fitter.
 Common values include "predictions", "log_lik", "loo", "epred". The metric
 will only receive these values in the context if the fitter provides
-them. \code{epred} is delivered as \code{context$loo_epred} inside the LOO context,
-so declare it alongside \code{"loo"} (as \code{rmse_loo_metric()} does); a metric
-declaring \code{needs = "epred"} alone never receives the matrix.}
+them. \code{epred} is delivered as \code{context$loo_epred}, a draws x observations
+matrix computed on the training set; it is delivered whether or not
+\code{"loo"} is also declared — without \code{"loo"} the matrix is built directly
+instead of through the LOO context.}
 
 \item{required}{Logical indicating whether metric failure causes task
 failure. If TRUE, an error in computing this metric will propagate and

--- a/man/build_loo_context.Rd
+++ b/man/build_loo_context.Rd
@@ -7,8 +7,12 @@
 build_loo_context(fitter, fit_result)
 }
 \value{
-A list with elements \code{loo}, \code{psis}, \code{log_lik}, \code{epred}, or NULL on
-failure. \code{psis}/\code{log_lik}/\code{epred} may be individually NULL if unavailable.
+A list with elements \code{loo}, \code{psis}, \code{log_lik}, \code{epred}, and
+\code{epred_attempted} (logical; whether \code{predict_epred()} was called), or
+NULL on failure. \code{psis}/\code{log_lik}/\code{epred} may be individually NULL if
+unavailable; when the train-set log-lik matrix fails the function bails
+with \code{epred_attempted = FALSE} so the caller can still build epred
+directly (it does not depend on the log-lik).
 }
 \description{
 Constructs the full LOO context for F3's rmse_loo / r2_loo metrics. Computes

--- a/man/build_metric_context.Rd
+++ b/man/build_metric_context.Rd
@@ -31,6 +31,9 @@ A named list containing any of:
 \item \code{predictions}: Prediction results from the fitter
 \item \code{log_lik}: Pointwise log-likelihood matrix (S x N)
 \item \code{loo}: LOO-CV results
+\item \code{loo_psis}, \code{loo_psis_ll}, \code{loo_epred}: PSIS object, pointwise
+log-lik, and posterior-expectation predictions backing the LOO
+prediction metrics
 }
 }
 \description{
@@ -47,6 +50,9 @@ Evaluation data: \code{predictions} and \code{log_lik} are computed on the TEST 
 when \code{data_bundle$test} is present, otherwise on the training set. Every
 built-in metric that consumes them (\verb{pred_*}, \code{elpd_test}, \code{r2_test}) compares against the test response, so the predictions must be
 for the test rows. The LOO context is always built on the training set —
-leave-one-out is in-sample by construction.
+leave-one-out is in-sample by construction. \code{loo_epred} is likewise a
+training-set matrix; when no metric needs \code{"loo"} (or the fitter lacks LOO
+support) it is built directly via \code{\link[=predict_epred]{predict_epred()}} rather than through
+the LOO context, so declaring \code{needs = "epred"} alone still delivers it.
 }
 \keyword{internal}

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -1154,6 +1154,58 @@ describe("Worker", {
       expect_true(all(is.na(out)))
     })
 
+    it("builds epred when the LOO context bails at the train-set log-lik (#68)", {
+      # build_loo_context() returns a partial context (loo summary only) when
+      # log_lik_matrix() fails, never attempting epred there; the direct
+      # fallback must still deliver the matrix (coderabbit review on #70).
+      bayesim:::.reset_warn_once()
+      BrokenLlFitter <- S7::new_class("BrokenLlFitter", parent = MockFitter)
+      S7::method(log_lik_matrix, BrokenLlFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        stop("ll boom")
+      }
+      S7::method(predict_epred, BrokenLlFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(500), nrow = 50, ncol = 10)
+      }
+      fitter <- BrokenLlFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+      metric <- list(create_test_metric(
+        name = "both",
+        needs = c("loo", "epred")
+      ))
+
+      context <- expect_silent(build_metric_context(
+        fit_result,
+        fitter,
+        data_bundle,
+        metric
+      ))
+
+      # Partial LOO context: the summary is present, the PSIS machinery is
+      # not (rmse_loo/r2_loo NA-degrade on the missing psis/log_lik)...
+      expect_false(is.null(context[["loo"]]))
+      expect_null(context$loo_psis)
+      expect_null(context$loo_psis_ll)
+      # ...but epred does not depend on the log-lik and must be delivered.
+      expect_equal(dim(context$loo_epred), c(50, 10))
+    })
+
     it("warns once when an epred-only metric's predict_epred fails (#68)", {
       bayesim:::.reset_warn_once()
       BrokenEpredOnlyFitter <- S7::new_class(

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -1007,6 +1007,184 @@ describe("Worker", {
       expect_true(is.null(context$loo_epred))
       expect_false(is.null(context$loo))
     })
+
+    it("builds epred for a metric declaring needs = \"epred\" alone (#68)", {
+      # epred used to be built only inside the LOO branch, so an epred-only
+      # metric silently received context$loo_epred = NULL. The matrix must
+      # now be built directly, without the LOO machinery.
+      bayesim:::.reset_warn_once()
+      EpredCapableFitter <- S7::new_class(
+        "EpredCapableFitter",
+        parent = MockFitter
+      )
+      S7::method(predict_epred, EpredCapableFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(500), nrow = 50, ncol = 10)
+      }
+      fitter <- EpredCapableFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+      # Build the metric outside expect_silent: registering a fresh S7 class
+      # emits messages that expect_silent would flag.
+      metric <- list(create_test_metric(name = "epred_only", needs = "epred"))
+
+      context <- expect_silent(build_metric_context(
+        fit_result,
+        fitter,
+        data_bundle,
+        metric
+      ))
+
+      # epred on the training set: 50 draws x 10 observations.
+      expect_equal(dim(context$loo_epred), c(50, 10))
+      # No "loo" need: the LOO context must not be built. Exact [[ ]] access —
+      # $loo would partially match loo_epred.
+      expect_true(is.null(context[["loo"]]))
+      expect_true(is.null(context[["loo_psis"]]))
+      expect_true(is.null(context[["loo_psis_ll"]]))
+    })
+
+    it("builds epred without LOO support when \"loo\" is also declared (#68)", {
+      # needs = c("loo", "epred") on a supports_loo = FALSE fitter: the LOO
+      # branch is skipped (warn-once), but epred no longer disappears with it.
+      bayesim:::.reset_warn_once()
+      EpredNoLooFitter <- S7::new_class(
+        "EpredNoLooFitter",
+        parent = MockFitter
+      )
+      S7::method(predict_epred, EpredNoLooFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(500), nrow = 50, ncol = 10)
+      }
+      fitter <- EpredNoLooFitter()
+      fitter@supports_epred <- TRUE
+      fitter@supports_loo <- FALSE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- NULL
+      expect_warning(
+        context <- build_metric_context(
+          fit_result,
+          fitter,
+          data_bundle,
+          list(create_test_metric(name = "both", needs = c("loo", "epred")))
+        ),
+        "Metric requires loo but fitter does not support it"
+      )
+      expect_true(is.null(context[["loo"]]))
+      expect_equal(dim(context$loo_epred), c(50, 10))
+    })
+
+    it("warns once when an epred-only metric's predict_epred fails (#68)", {
+      bayesim:::.reset_warn_once()
+      BrokenEpredOnlyFitter <- S7::new_class(
+        "BrokenEpredOnlyFitter",
+        parent = MockFitter
+      )
+      S7::method(predict_epred, BrokenEpredOnlyFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        stop("boom")
+      }
+      fitter <- BrokenEpredOnlyFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      metric <- list(create_test_metric(name = "epred_only", needs = "epred"))
+
+      context <- NULL
+      expect_warning(
+        context <- build_metric_context(
+          fit_result,
+          fitter,
+          data_bundle,
+          metric
+        ),
+        "predict_epred\\(\\) failed"
+      )
+      expect_true(is.null(context$loo_epred))
+      # Warn once per run, not per task.
+      expect_silent(build_metric_context(
+        fit_result,
+        fitter,
+        data_bundle,
+        metric
+      ))
+    })
+
+    it("degrades a wrong-shaped epred through the warn-once path without loo (#68)", {
+      # Outside the LOO context there is no log-lik matrix to align draws
+      # against, but the observation count must still match the training set.
+      bayesim:::.reset_warn_once()
+      BadShapeEpredOnlyFitter <- S7::new_class(
+        "BadShapeEpredOnlyFitter",
+        parent = MockFitter
+      )
+      S7::method(predict_epred, BadShapeEpredOnlyFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(10), nrow = 5, ncol = 2)
+      }
+      fitter <- BadShapeEpredOnlyFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- NULL
+      expect_warning(
+        context <- build_metric_context(
+          fit_result,
+          fitter,
+          data_bundle,
+          list(create_test_metric(name = "epred_only", needs = "epred"))
+        ),
+        "predict_epred\\(\\) failed"
+      )
+      # The malformed matrix must not reach the metric context.
+      expect_true(is.null(context$loo_epred))
+      expect_true(is.null(context[["loo"]]))
+    })
   })
 
   describe("compute_all_metrics()", {

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -1097,6 +1097,63 @@ describe("Worker", {
       expect_equal(dim(context$loo_epred), c(50, 10))
     })
 
+    it("elpd_loo composed with an epred metric NA-degrades without LOO support (#68)", {
+      # Regression for the $-partial-match hazard (pullfrog review on #70):
+      # this branch can produce a context carrying loo_epred without a loo
+      # summary, and a $-reading metric must not receive the epred matrix
+      # via context$loo.
+      bayesim:::.reset_warn_once()
+      EpredNoLooComposeFitter <- S7::new_class(
+        "EpredNoLooComposeFitter",
+        parent = MockFitter
+      )
+      S7::method(predict_epred, EpredNoLooComposeFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(500), nrow = 50, ncol = 10)
+      }
+      fitter <- EpredNoLooComposeFitter()
+      fitter@supports_epred <- TRUE
+      fitter@supports_loo <- FALSE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      metrics <- list(elpd_loo_metric(), rmse_loo_metric())
+      context <- NULL
+      expect_warning(
+        context <- build_metric_context(
+          fit_result,
+          fitter,
+          data_bundle,
+          metrics
+        ),
+        "Metric requires loo but fitter does not support it"
+      )
+      # The pinned NULL binding must win over $ partial matching of loo_epred.
+      expect_null(context$loo)
+      expect_equal(dim(context$loo_epred), c(50, 10))
+
+      # The loo-only metric degrades to clean NAs, not an error from being
+      # handed the epred matrix.
+      out <- compute_metric(
+        elpd_loo_metric(),
+        fit_result,
+        data_bundle,
+        context,
+        list(task_id = "t1", rep_idx = 1L)
+      )
+      expect_true(all(is.na(out)))
+    })
+
     it("warns once when an epred-only metric's predict_epred fails (#68)", {
       bayesim:::.reset_warn_once()
       BrokenEpredOnlyFitter <- S7::new_class(


### PR DESCRIPTION
Fixes #68.

## Problem

`build_metric_context()` only built the epred matrix under the LOO branch, gated on `"loo" %in% all_needs && fitter@supports_loo`. A custom metric declaring `needs = "epred"` *without* `"loo"` therefore never received `context$loo_epred` and silently computed on a missing context element — NA-degrading (or erroring, depending on how it reads the context) with no explanation:

- the `loo` branch does not run, so `loo_epred` is absent;
- neither warn-once covers the shape: `unsupported_capability.epred` fires only when `supports_epred = FALSE`, and `loo_epred_failed` only inside the (never-built) LOO context.

Same silent-degradation class as #62, found during the #62 review and deferred from #67.

## Fix

- **`build_metric_context()`** now builds epred directly whenever `"epred" %in% all_needs` and the LOO context was not built — i.e. no `"loo"` need, unsupported LOO, or a failed LOO build — calling `predict_epred()` + `validate_fitter_epred()` and delivering the matrix as `context$loo_epred`. A new warn-once `epred_build_failed` explains the NA degradation when `predict_epred()` fails or returns a wrong-shaped matrix. Deliberately no `is_fatal_error()` re-stop: a wrong-shaped return raises a contract error and must degrade through the warn-once exactly as it does when built via the LOO context.
- **`validate_fitter_epred()`** accepts `n_draws = NULL` for callers without a paired log-lik matrix (only the observation count and a non-empty draws dimension are checked then), and the error message drops the log-lik alignment phrasing in that case.
- **`Metric` `needs` doc**: epred is delivered whether or not `"loo"` is also declared — replacing the PR #67-era workaround text that told users to always declare `"loo"` alongside.

## Tests

Four new cases in `test-engine.R` next to the #62/#67 seam tests: epred-only metric receives the matrix (and no LOO context is built); `needs = c("loo", "epred")` on a `supports_loo = FALSE` fitter still gets epred; a failing `predict_epred()` warns exactly once; a wrong-shaped return degrades through the warn-once path. Verified locally: core tier (1371 pass), backend `loo-metrics-parity` (11 pass), `air format --check`, `jarl check`, and `R CMD check` (only the known #56 codoc WARNING).

## Out of scope

The related inefficiency (`build_loo_context()` always computing PSIS and epred even for `needs = "loo"` alone) is split into #69 because it has a contract question attached (what a `"loo"`-only metric may read), keeping this PR a pure fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics requiring expected predictions can now calculate them independently, even when LOO information is unavailable or unsupported.
  * Prediction context now provides training-set expected predictions whenever available.
* **Bug Fixes**
  * Improved handling of missing, invalid, or malformed prediction results with safe NA fallback and warn-once behavior.
  * Prevented incorrect metric context lookups that could produce inaccurate results.
* **Documentation**
  * Clarified how expected predictions and LOO-related context are provided to metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->