### PR TITLE
Count only pending rows in checkpoint meta.json n_pending

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,11 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
 
 ## Engine and resume
 
+* Checkpoint `meta.json` diagnostics no longer conflate policy-stopped work
+  with genuinely pending work: `n_pending` now counts only rows labeled
+  `pending`, so it no longer double-counts the policy-stopped tasks that
+  `n_policy_stopped` already reports. The resumable row count remains
+  derivable as `n_tasks - n_success - n_failed` (#65).
 * Resumed task grids no longer lose policy-stop labels when the resumed run
   stops before executing anything (e.g. the carried-over failure count
   already exhausts an unchanged `max_errors` budget): tasks restored from

--- a/R/checkpoint.R
+++ b/R/checkpoint.R
@@ -552,10 +552,7 @@ write_checkpoint <- function(
         n_tasks = nrow(task_grid),
         n_success = sum(task_grid$status == "success", na.rm = TRUE),
         n_failed = sum(task_grid$status == "failed", na.rm = TRUE),
-        n_pending = sum(
-          is_resumable_task_status(task_grid$status),
-          na.rm = TRUE
-        ),
+        n_pending = sum(task_grid$status == "pending", na.rm = TRUE),
         n_policy_stopped = if ("stop_reason" %in% names(task_grid)) {
           sum(
             task_grid$status == "skipped" &

--- a/tests/testthat/test-checkpoint.R
+++ b/tests/testthat/test-checkpoint.R
@@ -474,6 +474,48 @@ describe("Checkpoint Writing", {
       expect_equal(meta$n_pending, 1)
     })
 
+    it("counts policy-stopped tasks in n_policy_stopped, not n_pending", {
+      tmpdir <- withr::local_tempdir()
+      result_path <- file.path(tmpdir, "results")
+      init_checkpoint_dir(result_path, config_fingerprint = "test_fingerprint")
+
+      # Mirrors a max_errors stop: one failed task, three policy-stopped
+      # placeholders, one row still genuinely pending.
+      task_grid <- data.frame(
+        task_id = c("t1", "t2", "t3", "t4", "t5"),
+        status = c("failed", "skipped", "skipped", "skipped", "pending"),
+        stop_reason = c(
+          "fit_error",
+          "max_errors",
+          "max_errors",
+          "adaptive_stop",
+          NA_character_
+        ),
+        stringsAsFactors = FALSE
+      )
+      task_results <- list(
+        create_test_task_result(task_id = "t1", status = "failed")
+      )
+
+      write_checkpoint(
+        result_path = result_path,
+        task_grid = task_grid,
+        task_results = task_results,
+        config_fingerprint = "test_fp"
+      )
+
+      meta <- jsonlite::read_json(file.path(
+        result_path,
+        "checkpoints",
+        "cp_000001",
+        "meta.json"
+      ))
+      expect_equal(meta$n_tasks, 5)
+      expect_equal(meta$n_failed, 1)
+      expect_equal(meta$n_pending, 1)
+      expect_equal(meta$n_policy_stopped, 3)
+    })
+
     it("creates ledger.rds with correct data", {
       tmpdir <- withr::local_tempdir()
       result_path <- file.path(tmpdir, "results")


### PR DESCRIPTION
## Summary

Closes #65.

`write_checkpoint()` computed `meta.json`'s `n_pending` as `sum(is_resumable_task_status(task_grid$status))`, and `is_resumable_task_status()` is TRUE for both `pending` **and** `skipped`. Every policy-stopped task was therefore counted twice — once in `n_pending` and once in `n_policy_stopped` — so the #64 repro (1 failed + 3 skipped, `max_errors = 1`) wrote a final meta reading `n_pending = 3, n_policy_stopped = 3` with zero rows actually labeled `pending`.

The fix is the one-liner the issue suggests: count `status == "pending"`, matching the style of the adjacent `n_success`/`n_failed` fields.

On the issue's open question — whether the resumable-count meaning is worth keeping as a separate field — I opted not to add `n_resumable`: statuses are exactly `pending`/`success`/`failed`/`skipped`, so the resumable total remains exactly derivable as `n_tasks - n_success - n_failed`, and nothing in the package or docs reads `n_pending` back (the field is write-only diagnostics; the only in-package `n_pending` is an unrelated local in `simulate.R`). A grep of tests and vignettes found no reliance on the old semantics either — the test helper `create_test_checkpoint()` already used the literal-pending semantics.

## Repro (from the issue)

Checkpoint with 1 failed + 3 skipped (`stop_reason = "max_errors"`):

| meta field | before | after |
|---|---|---|
| `n_pending` | 3 (wrong) | 0 |
| `n_policy_stopped` | 3 | 3 |

## Tests

- `test-checkpoint.R`: new case — a grid mixing one failed, three policy-stopped placeholders (both `max_errors` and `adaptive_stop` reasons), and one genuinely pending row asserts `n_pending = 1` and `n_policy_stopped = 3`. The existing `creates meta.json with correct fields` case still covers the simple path.
- `is_resumable_task_status()` itself is unchanged and still used by the resume logic (`simulate.R`, `resume.R`).

All touched files are in the fast tier; no new test files. Fast and core tiers pass locally, `air format . --check` and `jarl check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected checkpoint diagnostics so pending counts include only genuinely pending tasks.
  * Policy-stopped tasks are now reported separately and are not included in pending totals.
  * Improved checkpoint reporting for failed, policy-stopped, and pending tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->