### PR TITLE
Compute the train-set log-lik matrix and r_eff once on the PSIS path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,17 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
   NULL in such runs — custom metrics reading them must declare `"epred"`
   alongside `"loo"` (the documented `Metric` `needs` contract; the built-in
   `rmse_loo_metric()`/`r2_loo_metric()` already do).
+* On the weighted-prediction (PSIS) path the train-set log-lik matrix and
+  the chain-aware relative efficiencies are now computed once per task
+  instead of twice: `build_loo_context()` passes the matrix it computed to
+  `loo_fit()` through a new optional `log_lik` argument, and reuses the
+  `r_eff` that `loo_fit()` now returns for the PSIS object (#73). For
+  `CmdStanFitter()` this also means the PSIS weights finally use the same
+  chain-aware `r_eff` as the elpd summary (they silently ran without it
+  before). **Breaking for custom fitters**: `loo_fit()` methods must accept
+  the new `log_lik` argument (S7 requires method formals to match the
+  generic exactly) and may return `r_eff` alongside the summary fields;
+  standalone `loo_fit(fitter, fit_result)` calls are unchanged.
 
 ## Fitters and errors
 

--- a/R/brms-fitter.R
+++ b/R/brms-fitter.R
@@ -568,9 +568,12 @@ S7::method(loo_fit, BrmsFitter) <- function(
     return(NULL)
   }
 
-  # #73: reuse a caller-supplied train-set matrix; standalone callers pass
-  # NULL and pay the single computation here.
-  ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
+  # #73: reuse a caller-supplied train-set matrix. Standalone callers keep
+  # brms' canonical in-sample route (the fit's stored model frame): the
+  # newdata route behind log_lik_matrix() is a behavioral switch in brms
+  # (keeps rows dropped at fit time, re-samples me() latents) and errors for
+  # some model classes, so it must not become the fallback.
+  ll <- log_lik %||% brms::log_lik(fit_result$fit)
   # Chain-aware relative efficiency (A4): consistent with build_loo_context()
   # and brms::loo(). ll is S x N (draws x observations).
   r_eff <- relative_eff_from_chains(fitter, fit_result, ll)

--- a/R/brms-fitter.R
+++ b/R/brms-fitter.R
@@ -559,12 +559,18 @@ S7::method(predict_epred, BrmsFitter) <- function(
   brms::posterior_epred(fit_result$fit, newdata = data)
 }
 
-S7::method(loo_fit, BrmsFitter) <- function(fitter, fit_result) {
+S7::method(loo_fit, BrmsFitter) <- function(
+  fitter,
+  fit_result,
+  log_lik = NULL
+) {
   if (!fit_result$success || is.null(fit_result$fit)) {
     return(NULL)
   }
 
-  ll <- brms::log_lik(fit_result$fit)
+  # #73: reuse a caller-supplied train-set matrix; standalone callers pass
+  # NULL and pay the single computation here.
+  ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
   # Chain-aware relative efficiency (A4): consistent with build_loo_context()
   # and brms::loo(). ll is S x N (draws x observations).
   r_eff <- relative_eff_from_chains(fitter, fit_result, ll)
@@ -574,7 +580,9 @@ S7::method(loo_fit, BrmsFitter) <- function(fitter, fit_result) {
     elpd = loo_result$estimates["elpd_loo", "Estimate"],
     p_loo = loo_result$estimates["p_loo", "Estimate"],
     elpd_se = loo_result$estimates["elpd_loo", "SE"],
-    pareto_k = loo::pareto_k_values(loo_result)
+    pareto_k = loo::pareto_k_values(loo_result),
+    # Returned so build_loo_context() can reuse it for the PSIS object (#73).
+    r_eff = r_eff
   )
 }
 

--- a/R/cmdstan-fitter.R
+++ b/R/cmdstan-fitter.R
@@ -397,22 +397,31 @@ S7::method(predict_epred, CmdStanFitter_class) <- function(
 }
 
 # loo_fit ------------------------------------------------------------------
-S7::method(loo_fit, CmdStanFitter_class) <- function(fitter, fit_result) {
+S7::method(loo_fit, CmdStanFitter_class) <- function(
+  fitter,
+  fit_result,
+  log_lik = NULL
+) {
   if (is.null(fitter@log_lik_name)) {
     return(list(
       elpd = NA_real_,
       p_loo = NA_real_,
       elpd_se = NA_real_,
-      pareto_k = numeric()
+      pareto_k = numeric(),
+      r_eff = NULL
     ))
   }
-  ll <- tryCatch(log_lik_matrix(fitter, fit_result), error = function(e) NULL)
+  # #73: reuse a caller-supplied train-set matrix; standalone callers pass
+  # NULL and pay the single computation here.
+  ll <- log_lik %||%
+    tryCatch(log_lik_matrix(fitter, fit_result), error = function(e) NULL)
   if (is.null(ll)) {
     return(list(
       elpd = NA_real_,
       p_loo = NA_real_,
       elpd_se = NA_real_,
-      pareto_k = numeric()
+      pareto_k = numeric(),
+      r_eff = NULL
     ))
   }
 
@@ -444,14 +453,17 @@ S7::method(loo_fit, CmdStanFitter_class) <- function(fitter, fit_result) {
       elpd = NA_real_,
       p_loo = NA_real_,
       elpd_se = NA_real_,
-      pareto_k = numeric()
+      pareto_k = numeric(),
+      r_eff = NULL
     ))
   }
   list(
     elpd = loo_result$estimates["elpd_loo", "Estimate"],
     p_loo = loo_result$estimates["p_loo", "Estimate"],
     elpd_se = loo_result$estimates["elpd_loo", "SE"],
-    pareto_k = loo::pareto_k_values(loo_result)
+    pareto_k = loo::pareto_k_values(loo_result),
+    # Returned so build_loo_context() can reuse it for the PSIS object (#73).
+    r_eff = r_eff
   )
 }
 

--- a/R/fitter.R
+++ b/R/fitter.R
@@ -349,6 +349,13 @@ log_lik_matrix <- S7::new_generic(
 #'
 #' @param fitter An S7 Fitter object
 #' @param fit_result A `bayesim_fit_result` object from [fit_model()]
+#' @param log_lik Optional pointwise log-likelihood matrix (S x N, draws x
+#'   observations) for the training set, as returned by [log_lik_matrix()].
+#'   When supplied, methods should use it instead of recomputing their own;
+#'   `build_metric_context()` passes the matrix it already computed so the
+#'   weighted-prediction (PSIS) path pays for it once per task (#73). NULL
+#'   (the default, and for standalone calls) means the method computes its
+#'   own.
 #'
 #' @return A list containing:
 #'   \itemize{
@@ -356,12 +363,19 @@ log_lik_matrix <- S7::new_generic(
 #'     \item `p_loo`: Effective number of parameters (scalar)
 #'     \item `elpd_se`: Standard error of ELPD (scalar)
 #'     \item `pareto_k`: Pareto k diagnostic values (vector of length N)
+#'     \item `r_eff`: Chain-aware relative efficiencies used for the summary
+#'       (vector of length N), or NULL when none were computed (e.g. i.i.d.
+#'       draws). `build_metric_context()` reuses it for the PSIS object (#73).
 #'     \item Additional loo-specific diagnostics
 #'   }
 #' @export
-loo_fit <- S7::new_generic("loo_fit", "fitter", function(fitter, fit_result) {
-  S7::S7_dispatch()
-})
+loo_fit <- S7::new_generic(
+  "loo_fit",
+  "fitter",
+  function(fitter, fit_result, log_lik = NULL) {
+    S7::S7_dispatch()
+  }
+)
 
 #' @title Extract Fit Diagnostics
 #' @description
@@ -412,7 +426,7 @@ S7::method(log_lik_matrix, Fitter) <- function(
   NULL
 }
 
-S7::method(loo_fit, Fitter) <- function(fitter, fit_result) {
+S7::method(loo_fit, Fitter) <- function(fitter, fit_result, log_lik = NULL) {
   NULL
 }
 
@@ -744,13 +758,18 @@ S7::method(log_lik_matrix, MockFitter) <- function(
   })
 }
 
-S7::method(loo_fit, MockFitter) <- function(fitter, fit_result) {
+S7::method(loo_fit, MockFitter) <- function(
+  fitter,
+  fit_result,
+  log_lik = NULL
+) {
   if (is.null(fit_result) || is.null(fit_result$fit)) {
     return(list(
       elpd = NA_real_,
       p_loo = NA_real_,
       elpd_se = NA_real_,
-      pareto_k = numeric()
+      pareto_k = numeric(),
+      r_eff = NULL
     ))
   }
 
@@ -763,7 +782,8 @@ S7::method(loo_fit, MockFitter) <- function(fitter, fit_result) {
       elpd = -n_obs * 2,
       p_loo = 3,
       elpd_se = sqrt(n_obs) * 0.5,
-      pareto_k = runif(n_obs, -0.5, 0.5)
+      pareto_k = runif(n_obs, -0.5, 0.5),
+      r_eff = NULL
     )
   })
 }

--- a/R/fitter.R
+++ b/R/fitter.R
@@ -352,7 +352,7 @@ log_lik_matrix <- S7::new_generic(
 #' @param log_lik Optional pointwise log-likelihood matrix (S x N, draws x
 #'   observations) for the training set, as returned by [log_lik_matrix()].
 #'   When supplied, methods should use it instead of recomputing their own;
-#'   `build_metric_context()` passes the matrix it already computed so the
+#'   `build_loo_context()` passes the matrix it already computed so the
 #'   weighted-prediction (PSIS) path pays for it once per task (#73). NULL
 #'   (the default, and for standalone calls) means the method computes its
 #'   own.
@@ -365,7 +365,7 @@ log_lik_matrix <- S7::new_generic(
 #'     \item `pareto_k`: Pareto k diagnostic values (vector of length N)
 #'     \item `r_eff`: Chain-aware relative efficiencies used for the summary
 #'       (vector of length N), or NULL when none were computed (e.g. i.i.d.
-#'       draws). `build_metric_context()` reuses it for the PSIS object (#73).
+#'       draws). `build_loo_context()` reuses it for the PSIS object (#73).
 #'     \item Additional loo-specific diagnostics
 #'   }
 #' @export

--- a/R/linear-regression-fitter.R
+++ b/R/linear-regression-fitter.R
@@ -324,14 +324,21 @@ S7::method(log_lik_matrix, LinearRegressionFitter) <- function(
 }
 
 # loo_fit ------------------------------------------------------------------
-S7::method(loo_fit, LinearRegressionFitter) <- function(fitter, fit_result) {
-  ll <- log_lik_matrix(fitter, fit_result)
+S7::method(loo_fit, LinearRegressionFitter) <- function(
+  fitter,
+  fit_result,
+  log_lik = NULL
+) {
+  # #73: reuse a caller-supplied train-set matrix; standalone callers pass
+  # NULL and pay the single computation here.
+  ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
   if (is.null(ll)) {
     return(list(
       elpd = NA_real_,
       p_loo = NA_real_,
       elpd_se = NA_real_,
-      pareto_k = numeric()
+      pareto_k = numeric(),
+      r_eff = NULL
     ))
   }
   # i.i.d. draws => no chains; relative_eff is degenerate. PSIS-LOO still valid.
@@ -344,14 +351,16 @@ S7::method(loo_fit, LinearRegressionFitter) <- function(fitter, fit_result) {
       elpd = NA_real_,
       p_loo = NA_real_,
       elpd_se = NA_real_,
-      pareto_k = numeric()
+      pareto_k = numeric(),
+      r_eff = NULL
     ))
   }
   list(
     elpd = loo_result$estimates["elpd_loo", "Estimate"],
     p_loo = loo_result$estimates["p_loo", "Estimate"],
     elpd_se = loo_result$estimates["elpd_loo", "SE"],
-    pareto_k = loo::pareto_k_values(loo_result)
+    pareto_k = loo::pareto_k_values(loo_result),
+    r_eff = NULL
   )
 }
 

--- a/R/worker.R
+++ b/R/worker.R
@@ -689,12 +689,12 @@ build_metric_context <- function(
 #' matrix, and the posterior expectation predictions (epred) — all once, shared
 #' across metrics.
 #'
-#' The PSIS object uses `loo::psis(-ll, r_eff)` with per-observation
-#' relative-efficiency factors derived from the fit's chain structure via
-#' `posterior::as_draws_df(fit)$.chain` (matches brms' internal `r_eff_log_lik`
-#' exactly). Falls back to `r_eff = NULL` (with a captured warning) when chain
-#' structure is unavailable, which is mathematically valid but slightly less
-#' accurate.
+#' The PSIS object uses `loo::psis(-ll, r_eff)` with the chain-aware
+#' relative-efficiency factors that `loo_fit()` derived from the same matrix
+#' (`posterior::as_draws_df(fit)$.chain`, matching brms' internal
+#' `r_eff_log_lik`). Falls back to `r_eff = NULL` (with a captured warning)
+#' when chain structure is unavailable, which is mathematically valid but
+#' slightly less accurate.
 #'
 #' epred must be the posterior expectation (mu, no observation noise); for brms
 #' this is `brms::posterior_epred`. Only fitters with `supports_epred = TRUE`
@@ -715,16 +715,34 @@ build_metric_context <- function(
 #'   unavailable; when the train-set log-lik matrix fails the function bails
 #'   with `epred_attempted = FALSE` so the caller can still build epred
 #'   directly (it does not depend on the log-lik).
+#'
+#' @details
+#' The train-set log-lik matrix is computed once and shared: `loo_fit()`
+#' receives it through its `log_lik` argument, and the PSIS object reuses the
+#' chain-aware relative efficiencies that `loo_fit()` derived from the same
+#' matrix (falling back to [relative_eff_from_chains()] when the fitter's
+#' `loo_fit()` returns no `r_eff`). This keeps the summary and the PSIS
+#' weights consistent and avoids computing each twice per task (#73).
 #' @keywords internal
 build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
-  loo_result <- loo_fit(fitter, fit_result)
+  # Compute the train-set log-lik matrix once, before loo_fit(): the summary
+  # consumes it via the log_lik argument and the PSIS object below reads the
+  # same matrix, so the PSIS path pays for log_lik_matrix() once per task
+  # instead of twice (#73). With need_psis = FALSE no consumer exists;
+  # loo_fit() computes (and pays for) its own.
+  ll <- NULL
+  if (isTRUE(need_psis)) {
+    ll <- tryCatch(log_lik_matrix(fitter, fit_result), error = function(e) NULL)
+  }
+
+  loo_result <- loo_fit(fitter, fit_result, log_lik = ll)
   if (is.null(loo_result)) {
     return(NULL)
   }
 
-  # The train-set log-lik matrix, r_eff, the PSIS object, and epred only feed
-  # the weighted-prediction machinery; with need_psis = FALSE no metric reads
-  # them, so skip the work entirely (#69).
+  # The PSIS object, epred, and (from here on) the log-lik matrix itself only
+  # feed the weighted-prediction machinery; with need_psis = FALSE no metric
+  # reads them, so skip the work entirely (#69).
   if (!isTRUE(need_psis)) {
     return(list(
       loo = loo_result,
@@ -735,8 +753,8 @@ build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
     ))
   }
 
-  # Pointwise log-likelihood matrix (S x N, draws x observations).
-  ll <- tryCatch(log_lik_matrix(fitter, fit_result), error = function(e) NULL)
+  # Train-set log-lik matrix unavailable (failed, or not matrix-shaped): bail
+  # with epred_attempted = FALSE so the caller can still build epred directly.
   if (!is.matrix(ll)) {
     return(list(
       loo = loo_result,
@@ -747,11 +765,16 @@ build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
     ))
   }
 
-  # Per-observation relative-efficiency via chain structure.
-  r_eff <- tryCatch(
-    relative_eff_from_chains(fitter, fit_result, ll),
-    error = function(e) NULL
-  )
+  # #73: reuse the chain-aware relative efficiencies loo_fit() derived from
+  # the same matrix; derive them here only when the fitter's loo_fit() did
+  # not return any.
+  r_eff <- loo_result$r_eff
+  if (is.null(r_eff)) {
+    r_eff <- tryCatch(
+      relative_eff_from_chains(fitter, fit_result, ll),
+      error = function(e) NULL
+    )
+  }
 
   # PSIS object. If r_eff is NULL (no chain info) loo::psis warns and proceeds
   # without the efficiency correction — mathematically valid, slightly less

--- a/R/worker.R
+++ b/R/worker.R
@@ -767,8 +767,9 @@ build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
 
   # #73: reuse the chain-aware relative efficiencies loo_fit() derived from
   # the same matrix; derive them here only when the fitter's loo_fit() did
-  # not return any.
-  r_eff <- loo_result$r_eff
+  # not return any. Exact [[ ]] read: loo_result is a fitter-controlled list
+  # where $ would partial-match.
+  r_eff <- loo_result[["r_eff"]]
   if (is.null(r_eff)) {
     r_eff <- tryCatch(
       relative_eff_from_chains(fitter, fit_result, ll),

--- a/man/build_loo_context.Rd
+++ b/man/build_loo_context.Rd
@@ -31,16 +31,23 @@ matrix, and the posterior expectation predictions (epred) — all once, shared
 across metrics.
 }
 \details{
-The PSIS object uses \code{loo::psis(-ll, r_eff)} with per-observation
-relative-efficiency factors derived from the fit's chain structure via
-\code{posterior::as_draws_df(fit)$.chain} (matches brms' internal \code{r_eff_log_lik}
-exactly). Falls back to \code{r_eff = NULL} (with a captured warning) when chain
-structure is unavailable, which is mathematically valid but slightly less
-accurate.
+The PSIS object uses \code{loo::psis(-ll, r_eff)} with the chain-aware
+relative-efficiency factors that \code{loo_fit()} derived from the same matrix
+(\code{posterior::as_draws_df(fit)$.chain}, matching brms' internal
+\code{r_eff_log_lik}). Falls back to \code{r_eff = NULL} (with a captured warning)
+when chain structure is unavailable, which is mathematically valid but
+slightly less accurate.
 
 epred must be the posterior expectation (mu, no observation noise); for brms
 this is \code{brms::posterior_epred}. Only fitters with \code{supports_epred = TRUE}
 are asked for it via \code{predict_epred()}; otherwise epred is NULL and the
 consuming metrics (r2_loo, rmse_loo) degrade to NA.
+
+The train-set log-lik matrix is computed once and shared: \code{loo_fit()}
+receives it through its \code{log_lik} argument, and the PSIS object reuses the
+chain-aware relative efficiencies that \code{loo_fit()} derived from the same
+matrix (falling back to \code{\link[=relative_eff_from_chains]{relative_eff_from_chains()}} when the fitter's
+\code{loo_fit()} returns no \code{r_eff}). This keeps the summary and the PSIS
+weights consistent and avoids computing each twice per task (#73).
 }
 \keyword{internal}

--- a/man/loo_fit.Rd
+++ b/man/loo_fit.Rd
@@ -4,12 +4,20 @@
 \alias{loo_fit}
 \title{Compute LOO-CV}
 \usage{
-loo_fit(fitter, fit_result)
+loo_fit(fitter, fit_result, log_lik = NULL)
 }
 \arguments{
 \item{fitter}{An S7 Fitter object}
 
 \item{fit_result}{A \code{bayesim_fit_result} object from \code{\link[=fit_model]{fit_model()}}}
+
+\item{log_lik}{Optional pointwise log-likelihood matrix (S x N, draws x
+observations) for the training set, as returned by \code{\link[=log_lik_matrix]{log_lik_matrix()}}.
+When supplied, methods should use it instead of recomputing their own;
+\code{build_metric_context()} passes the matrix it already computed so the
+weighted-prediction (PSIS) path pays for it once per task (#73). NULL
+(the default, and for standalone calls) means the method computes its
+own.}
 }
 \value{
 A list containing:
@@ -18,6 +26,9 @@ A list containing:
 \item \code{p_loo}: Effective number of parameters (scalar)
 \item \code{elpd_se}: Standard error of ELPD (scalar)
 \item \code{pareto_k}: Pareto k diagnostic values (vector of length N)
+\item \code{r_eff}: Chain-aware relative efficiencies used for the summary
+(vector of length N), or NULL when none were computed (e.g. i.i.d.
+draws). \code{build_metric_context()} reuses it for the PSIS object (#73).
 \item Additional loo-specific diagnostics
 }
 }

--- a/man/loo_fit.Rd
+++ b/man/loo_fit.Rd
@@ -14,7 +14,7 @@ loo_fit(fitter, fit_result, log_lik = NULL)
 \item{log_lik}{Optional pointwise log-likelihood matrix (S x N, draws x
 observations) for the training set, as returned by \code{\link[=log_lik_matrix]{log_lik_matrix()}}.
 When supplied, methods should use it instead of recomputing their own;
-\code{build_metric_context()} passes the matrix it already computed so the
+\code{build_loo_context()} passes the matrix it already computed so the
 weighted-prediction (PSIS) path pays for it once per task (#73). NULL
 (the default, and for standalone calls) means the method computes its
 own.}
@@ -28,7 +28,7 @@ A list containing:
 \item \code{pareto_k}: Pareto k diagnostic values (vector of length N)
 \item \code{r_eff}: Chain-aware relative efficiencies used for the summary
 (vector of length N), or NULL when none were computed (e.g. i.i.d.
-draws). \code{build_metric_context()} reuses it for the PSIS object (#73).
+draws). \code{build_loo_context()} reuses it for the PSIS object (#73).
 \item Additional loo-specific diagnostics
 }
 }

--- a/tests/testthat/test-cmdstan-fitter.R
+++ b/tests/testthat/test-cmdstan-fitter.R
@@ -79,6 +79,12 @@ describe("CmdStanFitter fit + draws + diagnostics", {
     # loo works.
     loo <- loo_fit(fitter, res)
     expect_false(is.na(loo$elpd))
+
+    # #73: a supplied train-set matrix yields the identical summary (the
+    # engine passes the matrix it computed for the PSIS context).
+    loo_passed <- loo_fit(fitter, res, log_lik = ll)
+    expect_equal(loo_passed, loo)
+    expect_false(is.null(loo_passed$r_eff))
   })
 
   it("errors when log_lik is needed but not declared", {

--- a/tests/testthat/test-contracts.R
+++ b/tests/testthat/test-contracts.R
@@ -349,6 +349,48 @@ describe("Fitter Class", {
     })
   })
 
+  # #73: the NA-degradation paths of loo_fit() must return the same
+  # documented structure (now including r_eff) instead of erroring, without
+  # requiring a compiled Stan backend to exercise.
+  describe("loo_fit() NA degradation (#73)", {
+    it("MockFitter returns the NA structure when the fit object is missing", {
+      out <- loo_fit(MockFitter(), list(success = TRUE))
+      expect_setequal(
+        names(out),
+        c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff")
+      )
+      expect_true(all(is.na(out[c("elpd", "p_loo", "elpd_se")])))
+      expect_length(out$pareto_k, 0)
+      expect_null(out$r_eff)
+    })
+
+    it("CmdStanFitter without a log_lik GQ degrades without touching the fit", {
+      fitter <- CmdStanFitter(
+        stan_code = "parameters { real y; } model { y ~ normal(0, 1); }",
+        stan_data = function(data_bundle, fit_spec) list()
+      )
+      expect_null(fitter@log_lik_name)
+      out <- loo_fit(fitter, list())
+      expect_true(all(is.na(out[c("elpd", "p_loo", "elpd_se")])))
+      expect_length(out$pareto_k, 0)
+      expect_null(out$r_eff)
+    })
+
+    it("CmdStanFitter degrades to NA when the draws cannot be extracted", {
+      fitter <- CmdStanFitter(
+        stan_code = "parameters { real y; } model { y ~ normal(0, 1); }",
+        stan_data = function(data_bundle, fit_spec) list(),
+        log_lik = "log_lik"
+      )
+      # A fit_result without a usable fit: log_lik_matrix() fails inside
+      # loo_fit()'s tryCatch and the summary degrades to NA.
+      out <- loo_fit(fitter, list(fit = NULL))
+      expect_true(all(is.na(out[c("elpd", "p_loo", "elpd_se")])))
+      expect_length(out$pareto_k, 0)
+      expect_null(out$r_eff)
+    })
+  })
+
   it("supports custom Fitter subclasses via S7 method registration", {
     TestFitter <- S7::new_class(
       "TestFitter",

--- a/tests/testthat/test-contracts.R
+++ b/tests/testthat/test-contracts.R
@@ -341,7 +341,7 @@ describe("Fitter Class", {
       loo_result <- loo_fit(fitter, out$fit)
       expect_setequal(
         names(loo_result),
-        c("elpd", "p_loo", "elpd_se", "pareto_k")
+        c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff")
       )
 
       diag <- fit_diagnostics(fitter, out$fit)

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -1167,6 +1167,75 @@ describe("Worker", {
       expect_equal(calls2$epred, 1L)
     })
 
+    it("computes the train-set log-lik matrix once on the PSIS path (#73)", {
+      # loo_fit() used to recompute the train-set log-lik matrix (and r_eff)
+      # that build_loo_context() had just computed. The matrix now travels to
+      # loo_fit() via its log_lik argument. The counting fitter mirrors
+      # BrmsFitter's shape: its loo_fit() derives from log_lik_matrix() when
+      # called without a precomputed matrix.
+      SharingLooFitter <- S7::new_class("SharingLooFitter", parent = MockFitter)
+      calls <- new.env(parent = emptyenv())
+      calls$log_lik <- 0L
+      S7::method(log_lik_matrix, SharingLooFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        calls$log_lik <- calls$log_lik + 1L
+        # Deterministic matrix so the handoff can be asserted by identity.
+        calls$last_ll <- matrix(seq_len(500) / 500, nrow = 50, ncol = 10)
+      }
+      S7::method(loo_fit, SharingLooFitter) <- function(
+        fitter,
+        fit_result,
+        log_lik = NULL
+      ) {
+        ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
+        calls$received_passed_ll <- !is.null(log_lik)
+        list(
+          elpd = -20,
+          p_loo = 3,
+          elpd_se = 1.5,
+          pareto_k = runif(ncol(ll)),
+          r_eff = NULL
+        )
+      }
+      S7::method(predict_epred, SharingLooFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(500), nrow = 50, ncol = 10)
+      }
+      fitter <- SharingLooFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- expect_silent(build_metric_context(
+        fit_result,
+        fitter,
+        data_bundle,
+        list(rmse_loo_metric())
+      ))
+
+      # Exactly one train-set log-lik computation feeds both the loo_fit()
+      # summary and the PSIS object...
+      expect_equal(calls$log_lik, 1L)
+      # ...and loo_fit() received the matrix the context computed.
+      expect_true(isTRUE(calls$received_passed_ll))
+      expect_identical(context$loo_psis_ll, calls$last_ll)
+      expect_false(is.null(context[["loo"]]))
+      expect_true(inherits(context$loo_psis, "psis"))
+    })
+
     it("builds epred without LOO support when \"loo\" is also declared (#68)", {
       # needs = c("loo", "epred") on a supports_loo = FALSE fitter: the LOO
       # branch is skipped (warn-once), but epred no longer disappears with it.

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -1170,9 +1170,10 @@ describe("Worker", {
     it("computes the train-set log-lik matrix once on the PSIS path (#73)", {
       # loo_fit() used to recompute the train-set log-lik matrix (and r_eff)
       # that build_loo_context() had just computed. The matrix now travels to
-      # loo_fit() via its log_lik argument. The counting fitter mirrors
-      # BrmsFitter's shape: its loo_fit() derives from log_lik_matrix() when
-      # called without a precomputed matrix.
+      # loo_fit() via its log_lik argument. The counting fitter mirrors the
+      # CmdStanFitter/LinearRegressionFitter shape: their loo_fit() derives
+      # from log_lik_matrix() when called without a precomputed matrix
+      # (BrmsFitter instead falls back to brms' stored model frame).
       SharingLooFitter <- S7::new_class("SharingLooFitter", parent = MockFitter)
       calls <- new.env(parent = emptyenv())
       calls$log_lik <- 0L

--- a/tests/testthat/test-fitter-orientation.R
+++ b/tests/testthat/test-fitter-orientation.R
@@ -146,8 +146,18 @@ describe("log_lik S x N orientation convention", {
       )
     }
 
-    S7::method(loo_fit, TransposedFitter) <- function(fitter, fit_result) {
-      list(elpd = -10, p_loo = 1, elpd_se = 1, pareto_k = numeric())
+    S7::method(loo_fit, TransposedFitter) <- function(
+      fitter,
+      fit_result,
+      log_lik = NULL
+    ) {
+      list(
+        elpd = -10,
+        p_loo = 1,
+        elpd_se = 1,
+        pareto_k = numeric(),
+        r_eff = NULL
+      )
     }
 
     S7::method(fit_diagnostics, TransposedFitter) <- function(
@@ -347,9 +357,16 @@ describe("predict_fit S x N orientation convention", {
 
     S7::method(loo_fit, PredictTransposedFitter) <- function(
       fitter,
-      fit_result
+      fit_result,
+      log_lik = NULL
     ) {
-      list(elpd = -10, p_loo = 1, elpd_se = 1, pareto_k = numeric())
+      list(
+        elpd = -10,
+        p_loo = 1,
+        elpd_se = 1,
+        pareto_k = numeric(),
+        r_eff = NULL
+      )
     }
 
     S7::method(fit_diagnostics, PredictTransposedFitter) <- function(

--- a/tests/testthat/test-linear-regression-fitter.R
+++ b/tests/testthat/test-linear-regression-fitter.R
@@ -138,6 +138,63 @@ describe("LinearRegressionFitter contract", {
     expect_equal(diag$ess_bulk, 250L)
     expect_equal(diag$divergent, 0L)
   })
+
+  it("loo_fit summarizes the train-set log-lik and reuses a supplied matrix (#73)", {
+    withr::local_seed(3)
+    n <- 25L
+    data_bundle <- list(
+      train = data.frame(y = stats::rnorm(n), x = stats::rnorm(n)),
+      test = NULL,
+      response = "y"
+    )
+    fitter <- LinearRegressionFitter(n_draws = 100L)
+    res <- fit_model(
+      fitter,
+      data_bundle,
+      list(formula = y ~ x),
+      seed = 1L,
+      task_ctx = list(task_id = "t")
+    )
+
+    # Standalone: computes its own matrix; bootstrap draws are i.i.d., so no
+    # chain-aware r_eff is available.
+    out <- loo_fit(fitter, res)
+    expect_false(is.na(out$elpd))
+    expect_false(is.na(out$p_loo))
+    expect_false(is.na(out$elpd_se))
+    expect_length(out$pareto_k, n)
+    expect_null(out$r_eff)
+
+    # Supplied matrix: identical summary without recomputation.
+    out_passed <- loo_fit(fitter, res, log_lik = log_lik_matrix(fitter, res))
+    expect_equal(out_passed, out)
+  })
+
+  it("loo_fit degrades to the NA structure on a degenerate log-lik (#73)", {
+    withr::local_seed(3)
+    data_bundle <- list(
+      train = data.frame(y = stats::rnorm(10), x = stats::rnorm(10)),
+      test = NULL,
+      response = "y"
+    )
+    fitter <- LinearRegressionFitter(n_draws = 100L)
+    res <- fit_model(
+      fitter,
+      data_bundle,
+      list(formula = y ~ x),
+      seed = 1L,
+      task_ctx = list(task_id = "t")
+    )
+    # A single draw cannot support PSIS smoothing; the summary degrades to NA.
+    out <- loo_fit(fitter, res, log_lik = matrix(rnorm(10), nrow = 1))
+    expect_setequal(
+      names(out),
+      c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff")
+    )
+    expect_true(all(is.na(out[c("elpd", "p_loo", "elpd_se")])))
+    expect_length(out$pareto_k, 0)
+    expect_null(out$r_eff)
+  })
 })
 
 describe("LinearRegressionFitter coverage", {

--- a/tests/testthat/test-linear-regression-fitter.R
+++ b/tests/testthat/test-linear-regression-fitter.R
@@ -185,7 +185,11 @@ describe("LinearRegressionFitter contract", {
       seed = 1L,
       task_ctx = list(task_id = "t")
     )
-    # A single draw cannot support PSIS smoothing; the summary degrades to NA.
+    # S = 1: loo::loo() hard-errors at one draw (psis_apply's internal
+    # vapply collapses the log-weights to a plain vector, tripping its
+    # is.matrix stopifnot) — a future loo that handles S = 1 gracefully
+    # would need this test re-pinned; the summary must degrade to NA, not
+    # propagate the error.
     out <- loo_fit(fitter, res, log_lik = matrix(rnorm(10), nrow = 1))
     expect_setequal(
       names(out),

--- a/tests/testthat/test-loo-metrics-parity.R
+++ b/tests/testthat/test-loo-metrics-parity.R
@@ -127,3 +127,33 @@ describe("loo_fit(BrmsFitter) parity with brms::loo (A4)", {
     expect_lt(abs(out$elpd_se - brms_loo$estimates["elpd_loo", "SE"]), 1e-6)
   })
 })
+
+# #73: loo_fit() accepts the train-set log-lik matrix its caller computed and
+# returns the r_eff it derived, so build_loo_context() computes each once.
+describe("loo_fit(BrmsFitter) with a supplied log_lik matrix (#73)", {
+  it("returns the identical summary and the r_eff it used", {
+    fitter <- BrmsFitter(chains = 1L, iter = 100L, warmup = 50L, cores = 1L)
+    out_passed <- loo_fit(fitter, fit_result, log_lik = ll)
+    out_own <- loo_fit(fitter, fit_result)
+    expect_equal(out_passed$elpd, out_own$elpd)
+    expect_equal(out_passed$p_loo, out_own$p_loo)
+    expect_equal(out_passed$elpd_se, out_own$elpd_se)
+    expect_equal(out_passed$pareto_k, out_own$pareto_k)
+    # The returned r_eff is the chain-aware correction the summary used,
+    # matching the fixture's manual relative_eff() computation.
+    expect_false(is.null(out_passed$r_eff))
+    expect_equal(out_passed$r_eff, r_eff)
+  })
+})
+
+describe("build_loo_context shares one log-lik and r_eff across summary and PSIS (#73)", {
+  it("delivers the same PSIS object as the manual construction", {
+    fitter <- BrmsFitter(chains = 1L, iter = 100L, warmup = 50L, cores = 1L)
+    ctx <- build_loo_context(fitter, fit_result, need_psis = TRUE)
+    expect_equal(ctx$log_lik, ll)
+    expect_equal(ctx$loo$elpd, loo_fit(fitter, fit_result)$elpd)
+    # The same chain-aware r_eff entered the PSIS smoothing as in the manual
+    # fixture (r_eff shifts the tail smoothing, hence pareto_k).
+    expect_equal(ctx$psis$diagnostics$pareto_k, psis_obj$diagnostics$pareto_k)
+  })
+})

--- a/vignettes/custom-fitters.Rmd
+++ b/vignettes/custom-fitters.Rmd
@@ -35,7 +35,7 @@ The public fitter contract is:
 | `predict_fit(fitter, fit_result, newdata, seed)` | optional; `supports_predictions = TRUE` | list with `predicted_mean` (length N), `predicted_samples` (S x N), `predicted_sd` (length N) |
 | `log_lik_matrix(fitter, fit_result, newdata)` | optional; `supports_log_lik = TRUE` | numeric log-likelihood matrix (S x N) |
 | `predict_epred(fitter, fit_result, newdata)` | optional; `supports_epred = TRUE` | numeric expectation matrix (S x N), or `NULL` when unsupported (`r2_loo` then degrades to NA) |
-| `loo_fit(fitter, fit_result)` | optional; `supports_loo = TRUE` | list with `elpd`, `p_loo`, `elpd_se`, `pareto_k` |
+| `loo_fit(fitter, fit_result, log_lik)` | optional; `supports_loo = TRUE` | list with `elpd`, `p_loo`, `elpd_se`, `pareto_k`, `r_eff` |
 | `fit_diagnostics(fitter, fit_result)` | optional | named diagnostic list; the default is `list()` |
 
 **All matrices are draws x observations (S x N)** — `predicted_samples`,
@@ -43,6 +43,15 @@ The public fitter contract is:
 observations in columns, matching the brms/loo convention. This is the single
 most common custom-fitter bug; `validate_fitter(smoke_test = TRUE)` rejects
 transposed matrices.
+
+`loo_fit()`'s `log_lik` argument is optional: when the engine builds the
+weighted-prediction (PSIS) context it passes the train-set log-lik matrix it
+already computed, and the method should reuse it instead of recomputing;
+standalone calls pass `NULL` and the method computes its own. Returning
+`r_eff` (the chain-aware relative efficiencies used for the summary, or
+`NULL`) likewise lets the engine reuse them for the PSIS object. A `loo_fit()`
+method registered without the `log_lik` argument is rejected by S7's strict
+signature checking.
 
 The generics avoid masking common names: `loo_fit` (not `loo::loo`),
 `log_lik_matrix` (not `brms::log_lik`), `fit_model` (not `generics::fit`).


### PR DESCRIPTION
Fixes #73.

## Problem

For a run whose metrics declare `c("loo", "epred")` (`rmse_loo_metric()` / `r2_loo_metric()`) on a `BrmsFitter`, the train-set pointwise log-lik matrix and the chain-aware relative efficiency were each computed **twice per task**:

1. `loo_fit(BrmsFitter)` internally called `brms::log_lik(fit)` + `relative_eff_from_chains()` to build the elpd summary;
2. `build_loo_context()` then called `log_lik_matrix()` (again `brms::log_lik`) + `relative_eff_from_chains()` again to build the PSIS object.

`CmdStanFitter` and `LinearRegressionFitter` had the same double-call shape (their `loo_fit()` derives from `log_lik_matrix()`). #69 already removed the double cost for the cheap `elpd_loo`-only configuration; this removes it for the weighted-prediction configuration.

## Change

- `loo_fit()` gains an optional `log_lik` argument: a precomputed **train-set** pointwise log-lik matrix (S x N). When supplied, methods reuse it instead of recomputing. Standalone callers (e.g. the A4 parity test) pass NULL and each fitter keeps its own derivation — for `BrmsFitter` that stays `brms::log_lik(fit)`, brms' canonical in-sample route via the stored model frame (the `newdata` route behind `log_lik_matrix()` is a behavioral switch in brms and must not become the fallback — see review thread).
- `loo_fit()` methods additionally return the `r_eff` they derived for the summary (NULL when none, e.g. i.i.d. draws), and `build_loo_context()` reuses it (exact `[["r_eff"]]` read) for the PSIS object, falling back to `relative_eff_from_chains()` when a fitter returns none.
- `build_loo_context()` computes the matrix once, **before** `loo_fit()`, and hands it over.

Behavior notes:

- **`CmdStanFitter()` correctness side effect**: the PSIS object previously always ran without `r_eff` on this path (`relative_eff_from_chains()` cannot read a cmdstan fit wrapper), while the elpd summary *did* use a chain-aware `r_eff`. Both now share the fitter-computed `r_eff`, so the PSIS weights behind `rmse_loo`/`r2_loo` are chain-corrected consistently with the summary. Values for CmdStan full-path runs shift slightly (more correct); no test asserted them before.
- **PSIS-path coherence**: on the weighted-prediction path the summary now derives from the same matrix as the PSIS weights and the epred matrix (both of which were already on the `newdata = train` route before this PR). The alternative — summary from the stored frame, weights from the train matrix — would report `pareto_k` for a different smoothing than the one backing `E_loo()`, and a stored-frame matrix (rows brms dropped at fit time) would fail the epred column-count alignment outright.
- **Breaking for custom fitters**: `loo_fit()` methods must accept the new `log_lik` argument (S7 requires method formals to match the generic exactly — old two-argument methods fail at registration with S7's own explanatory error) and may return `r_eff` alongside the summary fields. Standalone `loo_fit(fitter, fit_result)` calls are unchanged. Documented in NEWS and the custom-fitters vignette.

## Guard (from the issue)

Standalone `loo_fit()` calls keep working unchanged — the A4 parity test (`loo_fit(BrmsFitter)` ≡ `brms::loo()` within 1e-6) passes unmodified, plus new parity tests assert the supplied-`log_lik` summary is *identical* to the self-computed one and that the returned `r_eff` equals the manual `relative_eff()` computation.

## Tests

- `test-engine.R`: a counting fitter mirroring the `CmdStanFitter`/`LinearRegressionFitter` shape (`loo_fit()` deriving from `log_lik_matrix()` when called bare) proves the full PSIS path computes the matrix **exactly once** and that `loo_fit()` received the very matrix the context computed (asserted by identity).
- `test-loo-metrics-parity.R` (backend tier): supplied-`log_lik` summary identity, `r_eff` round-trip, and `build_loo_context()`'s PSIS pareto_k matching the manually constructed `psis(-ll, r_eff)` fixture.
- `test-contracts.R`: `loo_fit()` documented-structures set now includes `r_eff`; new core-tier NA-degradation suite (MockFitter missing fit, CmdStanFitter without a log_lik GQ / with unextractable draws) covers the new branches without a Stan backend.
- `test-linear-regression-fitter.R`: standalone summary (i.i.d. draws, `r_eff = NULL`), supplied-matrix identity, 1-draw NA degradation.
- `test-cmdstan-fitter.R` (backend tier): a supplied train-set matrix yields the identical summary with non-NULL `r_eff`.

## Local verification

- Core suite: `FAIL 0 | WARN 11 | SKIP 6 | PASS 1405+` (warnings pre-existing: mirai source-load notices + known fixtures)
- Backend tier (`loo-metrics-parity`, `cmdstan-fitter`, `metrics-brms`): `FAIL 0 | PASS 93+`
- `R CMD check`: 0 errors / 0 notes; the single WARNING is the documented upstream S7/codoc case (#56)
- `air format . --check`: clean; man pages regenerated
- Patch coverage 74.3% (26/35); the 9 uncovered lines are Stan-dependent branches exercised by the backend tier instead