### PR TITLE
Reuse loo_fit()'s retained PSIS object on the weighted-prediction path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,19 @@ Post-review hardening of the 2.0.0 engine, metrics, and analysis layer.
   the new `log_lik` argument (S7 requires method formals to match the
   generic exactly) and may return `r_eff` alongside the summary fields;
   standalone `loo_fit(fitter, fit_result)` calls are unchanged.
+* The PSIS tail smoothing itself also runs once per task on the
+  weighted-prediction path instead of twice: `build_loo_context()` calls
+  `loo_fit()` with `save_psis = TRUE` and reuses the retained `psis_object`
+  (what `loo::loo()` fitted internally for the summary — identical to
+  `loo::psis(-ll, r_eff)` on the same matrix) for the `loo::E_loo()`
+  weighted predictions, instead of smoothing the same tails a second time
+  (#76). Fitters that return no `psis_object` (custom fitters predating
+  this, the mock) keep the previous direct `loo::psis()` route.
+  **Breaking for custom fitters**: `loo_fit()` methods must accept the new
+  `save_psis` argument (same S7 formals rule as `log_lik` above); methods
+  computing their summary via `loo::loo()` should pass it through as
+  `save_psis` and return the retained object as `psis_object` (NULL when
+  not saved). Standalone `loo_fit(fitter, fit_result)` calls are unchanged.
 
 ## Fitters and errors
 

--- a/R/brms-fitter.R
+++ b/R/brms-fitter.R
@@ -562,7 +562,8 @@ S7::method(predict_epred, BrmsFitter) <- function(
 S7::method(loo_fit, BrmsFitter) <- function(
   fitter,
   fit_result,
-  log_lik = NULL
+  log_lik = NULL,
+  save_psis = FALSE
 ) {
   if (!fit_result$success || is.null(fit_result$fit)) {
     return(NULL)
@@ -577,7 +578,10 @@ S7::method(loo_fit, BrmsFitter) <- function(
   # Chain-aware relative efficiency (A4): consistent with build_loo_context()
   # and brms::loo(). ll is S x N (draws x observations).
   r_eff <- relative_eff_from_chains(fitter, fit_result, ll)
-  loo_result <- loo::loo(ll, r_eff = r_eff)
+  # #76: save_psis keeps the PSIS object loo::loo() fits internally; it is
+  # identical to loo::psis(-ll, r_eff), so the caller can reuse it instead
+  # of smoothing the tails a second time.
+  loo_result <- loo::loo(ll, r_eff = r_eff, save_psis = save_psis)
 
   list(
     elpd = loo_result$estimates["elpd_loo", "Estimate"],
@@ -585,7 +589,9 @@ S7::method(loo_fit, BrmsFitter) <- function(
     elpd_se = loo_result$estimates["elpd_loo", "SE"],
     pareto_k = loo::pareto_k_values(loo_result),
     # Returned so build_loo_context() can reuse it for the PSIS object (#73).
-    r_eff = r_eff
+    r_eff = r_eff,
+    # NULL unless save_psis = TRUE (#76).
+    psis_object = loo_result$psis_object
   )
 }
 

--- a/R/cmdstan-fitter.R
+++ b/R/cmdstan-fitter.R
@@ -400,7 +400,8 @@ S7::method(predict_epred, CmdStanFitter_class) <- function(
 S7::method(loo_fit, CmdStanFitter_class) <- function(
   fitter,
   fit_result,
-  log_lik = NULL
+  log_lik = NULL,
+  save_psis = FALSE
 ) {
   if (is.null(fitter@log_lik_name)) {
     return(list(
@@ -408,7 +409,8 @@ S7::method(loo_fit, CmdStanFitter_class) <- function(
       p_loo = NA_real_,
       elpd_se = NA_real_,
       pareto_k = numeric(),
-      r_eff = NULL
+      r_eff = NULL,
+      psis_object = NULL
     ))
   }
   # #73: reuse a caller-supplied train-set matrix; standalone callers pass
@@ -421,7 +423,8 @@ S7::method(loo_fit, CmdStanFitter_class) <- function(
       p_loo = NA_real_,
       elpd_se = NA_real_,
       pareto_k = numeric(),
-      r_eff = NULL
+      r_eff = NULL,
+      psis_object = NULL
     ))
   }
 
@@ -444,6 +447,9 @@ S7::method(loo_fit, CmdStanFitter_class) <- function(
   if (!is.null(r_eff)) {
     loo_args$r_eff <- r_eff
   }
+  # #76: save_psis keeps the PSIS object loo::loo() fits internally (NULL
+  # when FALSE), so the caller can reuse it instead of re-smoothing.
+  loo_args$save_psis <- save_psis
   loo_result <- tryCatch(
     suppressWarnings(do.call(loo::loo, loo_args)),
     error = function(e) NULL
@@ -454,7 +460,8 @@ S7::method(loo_fit, CmdStanFitter_class) <- function(
       p_loo = NA_real_,
       elpd_se = NA_real_,
       pareto_k = numeric(),
-      r_eff = NULL
+      r_eff = NULL,
+      psis_object = NULL
     ))
   }
   list(
@@ -463,7 +470,8 @@ S7::method(loo_fit, CmdStanFitter_class) <- function(
     elpd_se = loo_result$estimates["elpd_loo", "SE"],
     pareto_k = loo::pareto_k_values(loo_result),
     # Returned so build_loo_context() can reuse it for the PSIS object (#73).
-    r_eff = r_eff
+    r_eff = r_eff,
+    psis_object = loo_result$psis_object
   )
 }
 

--- a/R/fitter.R
+++ b/R/fitter.R
@@ -25,7 +25,7 @@
 #'   \item{`extract_draws(fitter, fit_result, variables = NULL)`}{Extract posterior draws}
 #'   \item{`predict_fit(fitter, fit_result, newdata = NULL, seed = NULL)`}{Generate predictions}
 #'   \item{`log_lik_matrix(fitter, fit_result, newdata = NULL)`}{Pointwise log-likelihood}
-#'   \item{`loo_fit(fitter, fit_result)`}{LOO-CV computation}
+#'   \item{`loo_fit(fitter, fit_result, log_lik, save_psis)`}{LOO-CV computation}
 #'   \item{`fit_diagnostics(fitter, fit_result)`}{Extract fit diagnostics}
 #' }
 #'
@@ -356,6 +356,12 @@ log_lik_matrix <- S7::new_generic(
 #'   weighted-prediction (PSIS) path pays for it once per task (#73). NULL
 #'   (the default, and for standalone calls) means the method computes its
 #'   own.
+#' @param save_psis Logical; when TRUE, methods that run the PSIS machinery
+#'   for the summary should keep the fitted PSIS object and return it as
+#'   `psis_object` (see below). `build_loo_context()` sets it on the
+#'   weighted-prediction path so the tail smoothing runs once per task
+#'   instead of twice (#76); the default FALSE discards it, as standalone
+#'   callers have no use for it.
 #'
 #' @return A list containing:
 #'   \itemize{
@@ -366,13 +372,21 @@ log_lik_matrix <- S7::new_generic(
 #'     \item `r_eff`: Chain-aware relative efficiencies used for the summary
 #'       (vector of length N), or NULL when none were computed (e.g. i.i.d.
 #'       draws). `build_loo_context()` reuses it for the PSIS object (#73).
+#'     \item `psis_object`: The fitted PSIS (importance-sampling) object the
+#'       summary was derived from, or NULL. Methods that compute the summary
+#'       via `loo::loo(ll, r_eff, save_psis = TRUE)` return its
+#'       `$psis_object`; it is identical to `loo::psis(-ll, r_eff)` on the
+#'       same matrix, so `build_loo_context()` reuses it for
+#'       `loo::E_loo()`-weighted predictions instead of smoothing the tails
+#'       a second time (#76). NULL when `save_psis = FALSE` or the fitter
+#'       does not fit a PSIS object at all.
 #'     \item Additional loo-specific diagnostics
 #'   }
 #' @export
 loo_fit <- S7::new_generic(
   "loo_fit",
   "fitter",
-  function(fitter, fit_result, log_lik = NULL) {
+  function(fitter, fit_result, log_lik = NULL, save_psis = FALSE) {
     S7::S7_dispatch()
   }
 )
@@ -426,7 +440,12 @@ S7::method(log_lik_matrix, Fitter) <- function(
   NULL
 }
 
-S7::method(loo_fit, Fitter) <- function(fitter, fit_result, log_lik = NULL) {
+S7::method(loo_fit, Fitter) <- function(
+  fitter,
+  fit_result,
+  log_lik = NULL,
+  save_psis = FALSE
+) {
   NULL
 }
 
@@ -761,7 +780,8 @@ S7::method(log_lik_matrix, MockFitter) <- function(
 S7::method(loo_fit, MockFitter) <- function(
   fitter,
   fit_result,
-  log_lik = NULL
+  log_lik = NULL,
+  save_psis = FALSE
 ) {
   if (is.null(fit_result) || is.null(fit_result$fit)) {
     return(list(
@@ -769,7 +789,8 @@ S7::method(loo_fit, MockFitter) <- function(
       p_loo = NA_real_,
       elpd_se = NA_real_,
       pareto_k = numeric(),
-      r_eff = NULL
+      r_eff = NULL,
+      psis_object = NULL
     ))
   }
 
@@ -783,7 +804,10 @@ S7::method(loo_fit, MockFitter) <- function(
       p_loo = 3,
       elpd_se = sqrt(n_obs) * 0.5,
       pareto_k = runif(n_obs, -0.5, 0.5),
-      r_eff = NULL
+      r_eff = NULL,
+      # The mock never runs the loo machinery, so no PSIS object exists to
+      # save (#76); the engine's fallback covers it.
+      psis_object = NULL
     )
   })
 }

--- a/R/linear-regression-fitter.R
+++ b/R/linear-regression-fitter.R
@@ -327,7 +327,8 @@ S7::method(log_lik_matrix, LinearRegressionFitter) <- function(
 S7::method(loo_fit, LinearRegressionFitter) <- function(
   fitter,
   fit_result,
-  log_lik = NULL
+  log_lik = NULL,
+  save_psis = FALSE
 ) {
   # #73: reuse a caller-supplied train-set matrix; standalone callers pass
   # NULL and pay the single computation here.
@@ -338,12 +339,15 @@ S7::method(loo_fit, LinearRegressionFitter) <- function(
       p_loo = NA_real_,
       elpd_se = NA_real_,
       pareto_k = numeric(),
-      r_eff = NULL
+      r_eff = NULL,
+      psis_object = NULL
     ))
   }
   # i.i.d. draws => no chains; relative_eff is degenerate. PSIS-LOO still valid.
+  # #76: save_psis keeps the PSIS object loo::loo() fits internally (NULL
+  # when FALSE), so the caller can reuse it instead of re-smoothing.
   loo_result <- tryCatch(
-    suppressWarnings(loo::loo(ll)),
+    suppressWarnings(loo::loo(ll, save_psis = save_psis)),
     error = function(e) NULL
   )
   if (is.null(loo_result)) {
@@ -352,7 +356,8 @@ S7::method(loo_fit, LinearRegressionFitter) <- function(
       p_loo = NA_real_,
       elpd_se = NA_real_,
       pareto_k = numeric(),
-      r_eff = NULL
+      r_eff = NULL,
+      psis_object = NULL
     ))
   }
   list(
@@ -360,7 +365,8 @@ S7::method(loo_fit, LinearRegressionFitter) <- function(
     p_loo = loo_result$estimates["p_loo", "Estimate"],
     elpd_se = loo_result$estimates["elpd_loo", "SE"],
     pareto_k = loo::pareto_k_values(loo_result),
-    r_eff = NULL
+    r_eff = NULL,
+    psis_object = loo_result$psis_object
   )
 }
 

--- a/R/worker.R
+++ b/R/worker.R
@@ -723,6 +723,11 @@ build_metric_context <- function(
 #' matrix (falling back to [relative_eff_from_chains()] when the fitter's
 #' `loo_fit()` returns no `r_eff`). This keeps the summary and the PSIS
 #' weights consistent and avoids computing each twice per task (#73).
+#' Since #76 the PSIS tail smoothing itself also runs only once:
+#' `loo_fit()` is called with `save_psis = TRUE` and its returned
+#' `psis_object` — identical to `loo::psis(-ll, r_eff)` on the same matrix —
+#' is reused directly; the direct `loo::psis()` route remains as a fallback
+#' for fitters that return no `psis_object` (e.g. custom or mock fitters).
 #' @keywords internal
 build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
   # Compute the train-set log-lik matrix once, before loo_fit(): the summary
@@ -735,7 +740,12 @@ build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
     ll <- tryCatch(log_lik_matrix(fitter, fit_result), error = function(e) NULL)
   }
 
-  loo_result <- loo_fit(fitter, fit_result, log_lik = ll)
+  loo_result <- loo_fit(
+    fitter,
+    fit_result,
+    log_lik = ll,
+    save_psis = isTRUE(need_psis)
+  )
   if (is.null(loo_result)) {
     return(NULL)
   }
@@ -765,28 +775,41 @@ build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
     ))
   }
 
-  # #73: reuse the chain-aware relative efficiencies loo_fit() derived from
-  # the same matrix; derive them here only when the fitter's loo_fit() did
-  # not return any. Exact [[ ]] read: loo_result is a fitter-controlled list
-  # where $ would partial-match.
-  r_eff <- loo_result[["r_eff"]]
-  if (is.null(r_eff)) {
-    r_eff <- tryCatch(
-      relative_eff_from_chains(fitter, fit_result, ll),
-      error = function(e) NULL
-    )
-  }
+  # #76: loo_fit() fitted the PSIS object as part of its summary when asked
+  # (save_psis = TRUE): loo::loo()'s internal run is identical to
+  # loo::psis(-ll, r_eff) on the same matrix, so reuse it instead of
+  # smoothing the same tails a second time. The pareto_k length check
+  # (exported, stable across loo versions) rejects a psis object fitted
+  # from a different matrix — e.g. a fitter that ignored the supplied
+  # log_lik — falling through to the direct route below.
+  psis_obj <- loo_result[["psis_object"]]
+  if (
+    !inherits(psis_obj, "psis") ||
+      !identical(length(loo::pareto_k_values(psis_obj)), ncol(ll))
+  ) {
+    # #73: derive the chain-aware relative efficiencies loo_fit() returned;
+    # fall back to relative_eff_from_chains() when the fitter's loo_fit()
+    # did not return any. Exact [[ ]] read: loo_result is a fitter-controlled
+    # list where $ would partial-match.
+    r_eff <- loo_result[["r_eff"]]
+    if (is.null(r_eff)) {
+      r_eff <- tryCatch(
+        relative_eff_from_chains(fitter, fit_result, ll),
+        error = function(e) NULL
+      )
+    }
 
-  # PSIS object. If r_eff is NULL (no chain info) loo::psis warns and proceeds
-  # without the efficiency correction — mathematically valid, slightly less
-  # accurate. Capture the warning so it doesn't surface per-task.
-  psis_obj <- if (!is.null(r_eff)) {
-    tryCatch(loo::psis(-ll, r_eff = r_eff), error = function(e) NULL)
-  } else {
-    tryCatch(
-      suppressWarnings(loo::psis(-ll)),
-      error = function(e) NULL
-    )
+    # PSIS object. If r_eff is NULL (no chain info) loo::psis warns and proceeds
+    # without the efficiency correction — mathematically valid, slightly less
+    # accurate. Capture the warning so it doesn't surface per-task.
+    psis_obj <- if (!is.null(r_eff)) {
+      tryCatch(loo::psis(-ll, r_eff = r_eff), error = function(e) NULL)
+    } else {
+      tryCatch(
+        suppressWarnings(loo::psis(-ll)),
+        error = function(e) NULL
+      )
+    }
   }
 
   # Posterior expectation predictions (mu, no noise). Required for r2_loo;

--- a/R/worker.R
+++ b/R/worker.R
@@ -778,15 +778,15 @@ build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
   # #76: loo_fit() fitted the PSIS object as part of its summary when asked
   # (save_psis = TRUE): loo::loo()'s internal run is identical to
   # loo::psis(-ll, r_eff) on the same matrix, so reuse it instead of
-  # smoothing the same tails a second time. The pareto_k length check
-  # (exported, stable across loo versions) rejects a psis object fitted
+  # smoothing the same tails a second time. The dim check on the log-weights
+  # matrix (S x N; named lw before loo 2.10) rejects a psis object fitted
   # from a different matrix — e.g. a fitter that ignored the supplied
-  # log_lik — falling through to the direct route below.
+  # log_lik or returned a differently-sized one — so a buggy fitter falls
+  # through to the direct route below instead of erroring opaquely inside
+  # loo::E_loo().
   psis_obj <- loo_result[["psis_object"]]
-  if (
-    !inherits(psis_obj, "psis") ||
-      !identical(length(loo::pareto_k_values(psis_obj)), ncol(ll))
-  ) {
+  psis_dim <- dim(psis_obj[["log_weights"]] %||% psis_obj[["lw"]])
+  if (!inherits(psis_obj, "psis") || !identical(psis_dim, dim(ll))) {
     # #73: derive the chain-aware relative efficiencies loo_fit() returned;
     # fall back to relative_eff_from_chains() when the fitter's loo_fit()
     # did not return any. Exact [[ ]] read: loo_result is a fitter-controlled

--- a/R/worker.R
+++ b/R/worker.R
@@ -779,7 +779,8 @@ build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
   # (save_psis = TRUE): loo::loo()'s internal run is identical to
   # loo::psis(-ll, r_eff) on the same matrix, so reuse it instead of
   # smoothing the same tails a second time. The dim check on the log-weights
-  # matrix (S x N; named lw before loo 2.10) rejects a psis object fitted
+  # matrix (S x N; spelled lw in older loo releases — log_weights is the
+  # name at least since 2.6) rejects a psis object fitted
   # from a different matrix — e.g. a fitter that ignored the supplied
   # log_lik or returned a differently-sized one — so a buggy fitter falls
   # through to the direct route below instead of erroring opaquely inside

--- a/R/worker.R
+++ b/R/worker.R
@@ -785,8 +785,16 @@ build_loo_context <- function(fitter, fit_result, need_psis = FALSE) {
   # through to the direct route below instead of erroring opaquely inside
   # loo::E_loo().
   psis_obj <- loo_result[["psis_object"]]
-  psis_dim <- dim(psis_obj[["log_weights"]] %||% psis_obj[["lw"]])
-  if (!inherits(psis_obj, "psis") || !identical(psis_dim, dim(ll))) {
+  if (
+    !inherits(psis_obj, "psis") ||
+      # Inside || so a non-list psis_object (e.g. a fitter that returned the
+      # save_psis flag itself) short-circuits to the fallback instead of
+      # erroring on [[.
+      !identical(
+        dim(psis_obj[["log_weights"]] %||% psis_obj[["lw"]]),
+        dim(ll)
+      )
+  ) {
     # #73: derive the chain-aware relative efficiencies loo_fit() returned;
     # fall back to relative_eff_from_chains() when the fitter's loo_fit()
     # did not return any. Exact [[ ]] read: loo_result is a fitter-controlled

--- a/man/Fitter.Rd
+++ b/man/Fitter.Rd
@@ -47,7 +47,7 @@ default to \code{NULL}.
 \item{\code{extract_draws(fitter, fit_result, variables = NULL)}}{Extract posterior draws}
 \item{\code{predict_fit(fitter, fit_result, newdata = NULL, seed = NULL)}}{Generate predictions}
 \item{\code{log_lik_matrix(fitter, fit_result, newdata = NULL)}}{Pointwise log-likelihood}
-\item{\code{loo_fit(fitter, fit_result)}}{LOO-CV computation}
+\item{\code{loo_fit(fitter, fit_result, log_lik, save_psis)}}{LOO-CV computation}
 \item{\code{fit_diagnostics(fitter, fit_result)}}{Extract fit diagnostics}
 }
 }

--- a/man/build_loo_context.Rd
+++ b/man/build_loo_context.Rd
@@ -49,5 +49,10 @@ chain-aware relative efficiencies that \code{loo_fit()} derived from the same
 matrix (falling back to \code{\link[=relative_eff_from_chains]{relative_eff_from_chains()}} when the fitter's
 \code{loo_fit()} returns no \code{r_eff}). This keeps the summary and the PSIS
 weights consistent and avoids computing each twice per task (#73).
+Since #76 the PSIS tail smoothing itself also runs only once:
+\code{loo_fit()} is called with \code{save_psis = TRUE} and its returned
+\code{psis_object} — identical to \code{loo::psis(-ll, r_eff)} on the same matrix —
+is reused directly; the direct \code{loo::psis()} route remains as a fallback
+for fitters that return no \code{psis_object} (e.g. custom or mock fitters).
 }
 \keyword{internal}

--- a/man/loo_fit.Rd
+++ b/man/loo_fit.Rd
@@ -4,7 +4,7 @@
 \alias{loo_fit}
 \title{Compute LOO-CV}
 \usage{
-loo_fit(fitter, fit_result, log_lik = NULL)
+loo_fit(fitter, fit_result, log_lik = NULL, save_psis = FALSE)
 }
 \arguments{
 \item{fitter}{An S7 Fitter object}
@@ -18,6 +18,13 @@ When supplied, methods should use it instead of recomputing their own;
 weighted-prediction (PSIS) path pays for it once per task (#73). NULL
 (the default, and for standalone calls) means the method computes its
 own.}
+
+\item{save_psis}{Logical; when TRUE, methods that run the PSIS machinery
+for the summary should keep the fitted PSIS object and return it as
+\code{psis_object} (see below). \code{build_loo_context()} sets it on the
+weighted-prediction path so the tail smoothing runs once per task
+instead of twice (#76); the default FALSE discards it, as standalone
+callers have no use for it.}
 }
 \value{
 A list containing:
@@ -29,6 +36,14 @@ A list containing:
 \item \code{r_eff}: Chain-aware relative efficiencies used for the summary
 (vector of length N), or NULL when none were computed (e.g. i.i.d.
 draws). \code{build_loo_context()} reuses it for the PSIS object (#73).
+\item \code{psis_object}: The fitted PSIS (importance-sampling) object the
+summary was derived from, or NULL. Methods that compute the summary
+via \code{loo::loo(ll, r_eff, save_psis = TRUE)} return its
+\verb{$psis_object}; it is identical to \code{loo::psis(-ll, r_eff)} on the
+same matrix, so \code{build_loo_context()} reuses it for
+\code{loo::E_loo()}-weighted predictions instead of smoothing the tails
+a second time (#76). NULL when \code{save_psis = FALSE} or the fitter
+does not fit a PSIS object at all.
 \item Additional loo-specific diagnostics
 }
 }

--- a/tests/testthat/test-cmdstan-fitter.R
+++ b/tests/testthat/test-cmdstan-fitter.R
@@ -85,6 +85,16 @@ describe("CmdStanFitter fit + draws + diagnostics", {
     loo_passed <- loo_fit(fitter, res, log_lik = ll)
     expect_equal(loo_passed, loo)
     expect_false(is.null(loo_passed$r_eff))
+
+    # #76: save_psis retains the PSIS object loo::loo() fitted internally —
+    # identical to a separate loo::psis(-ll, r_eff) run, so the engine can
+    # reuse it instead of re-smoothing the tails.
+    loo_saved <- loo_fit(fitter, res, log_lik = ll, save_psis = TRUE)
+    expect_true(inherits(loo_saved$psis_object, "psis"))
+    expect_identical(
+      loo_saved$psis_object,
+      suppressWarnings(loo::psis(-ll, r_eff = loo_saved$r_eff))
+    )
   })
 
   it("errors when log_lik is needed but not declared", {

--- a/tests/testthat/test-contracts.R
+++ b/tests/testthat/test-contracts.R
@@ -341,7 +341,7 @@ describe("Fitter Class", {
       loo_result <- loo_fit(fitter, out$fit)
       expect_setequal(
         names(loo_result),
-        c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff")
+        c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff", "psis_object")
       )
 
       diag <- fit_diagnostics(fitter, out$fit)
@@ -357,11 +357,12 @@ describe("Fitter Class", {
       out <- loo_fit(MockFitter(), list(success = TRUE))
       expect_setequal(
         names(out),
-        c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff")
+        c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff", "psis_object")
       )
       expect_true(all(is.na(out[c("elpd", "p_loo", "elpd_se")])))
       expect_length(out$pareto_k, 0)
       expect_null(out$r_eff)
+      expect_null(out$psis_object)
     })
 
     it("CmdStanFitter without a log_lik GQ degrades without touching the fit", {

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -1400,6 +1400,66 @@ describe("Worker", {
       expect_identical(dim(context$loo_psis$log_weights), c(50L, 10L))
     })
 
+    it("falls back when psis_object is not a psis object at all (#76)", {
+      # A non-list psis_object (e.g. a method that returned the save_psis
+      # flag itself) must short-circuit to the fallback, not error on [[
+      # and lose the whole LOO context — elpd summary included.
+      FlagPsisFitter <- S7::new_class("FlagPsisFitter", parent = MockFitter)
+      S7::method(log_lik_matrix, FlagPsisFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(seq_len(500) / 500, nrow = 50, ncol = 10)
+      }
+      S7::method(loo_fit, FlagPsisFitter) <- function(
+        fitter,
+        fit_result,
+        log_lik = NULL,
+        save_psis = FALSE
+      ) {
+        ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
+        list(
+          elpd = -20,
+          p_loo = 3,
+          elpd_se = 1.5,
+          pareto_k = runif(ncol(ll)),
+          r_eff = NULL,
+          psis_object = save_psis # the flag itself: atomic, not a psis object
+        )
+      }
+      S7::method(predict_epred, FlagPsisFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(500), nrow = 50, ncol = 10)
+      }
+      fitter <- FlagPsisFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- expect_silent(build_metric_context(
+        fit_result,
+        fitter,
+        data_bundle,
+        list(rmse_loo_metric())
+      ))
+
+      # The summary survives and the fallback built a usable PSIS object.
+      expect_false(is.null(context[["loo"]]))
+      expect_equal(context$loo$elpd, -20)
+      expect_true(inherits(context$loo_psis, "psis"))
+    })
+
     it("builds epred without LOO support when \"loo\" is also declared (#68)", {
       # needs = c("loo", "epred") on a supports_loo = FALSE fitter: the LOO
       # branch is skipped (warn-once), but epred no longer disappears with it.

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -1189,10 +1189,12 @@ describe("Worker", {
       S7::method(loo_fit, SharingLooFitter) <- function(
         fitter,
         fit_result,
-        log_lik = NULL
+        log_lik = NULL,
+        save_psis = FALSE
       ) {
         ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
         calls$received_passed_ll <- !is.null(log_lik)
+        calls$received_save_psis <- save_psis
         list(
           elpd = -20,
           p_loo = 3,
@@ -1232,9 +1234,167 @@ describe("Worker", {
       expect_equal(calls$log_lik, 1L)
       # ...and loo_fit() received the matrix the context computed.
       expect_true(isTRUE(calls$received_passed_ll))
+      # The PSIS path asks loo_fit() to retain its PSIS object (#76); this
+      # fitter returns none, so the loo::psis() fallback built the context's
+      # object.
+      expect_true(isTRUE(calls$received_save_psis))
       expect_identical(context$loo_psis_ll, calls$last_ll)
       expect_false(is.null(context[["loo"]]))
       expect_true(inherits(context$loo_psis, "psis"))
+    })
+
+    it("reuses loo_fit()'s psis_object instead of re-smoothing the tails (#76)", {
+      # The PSIS tail smoothing used to run twice: once inside loo_fit()'s
+      # loo::loo() and once more in build_loo_context()'s loo::psis(). Now
+      # loo_fit() receives save_psis = TRUE on the PSIS path and its returned
+      # psis_object — identical to loo::psis(-ll, r_eff) on the same matrix —
+      # is reused directly. This fitter mirrors the built-in implementations:
+      # it runs the real loo machinery and returns the retained object.
+      PsisSavingLooFitter <- S7::new_class(
+        "PsisSavingLooFitter",
+        parent = MockFitter
+      )
+      calls <- new.env(parent = emptyenv())
+      S7::method(log_lik_matrix, PsisSavingLooFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        # Deterministic matrix so the summary and the reused PSIS object are
+        # fitted from a known input.
+        matrix(seq_len(500) / 500, nrow = 50, ncol = 10)
+      }
+      S7::method(loo_fit, PsisSavingLooFitter) <- function(
+        fitter,
+        fit_result,
+        log_lik = NULL,
+        save_psis = FALSE
+      ) {
+        ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
+        calls$received_save_psis <- save_psis
+        loo_result <- suppressWarnings(loo::loo(ll, save_psis = save_psis))
+        calls$returned_psis <- loo_result$psis_object
+        calls$elpd <- loo_result$estimates["elpd_loo", "Estimate"]
+        list(
+          elpd = loo_result$estimates["elpd_loo", "Estimate"],
+          p_loo = loo_result$estimates["p_loo", "Estimate"],
+          elpd_se = loo_result$estimates["elpd_loo", "SE"],
+          pareto_k = loo::pareto_k_values(loo_result),
+          r_eff = NULL,
+          psis_object = loo_result$psis_object
+        )
+      }
+      S7::method(predict_epred, PsisSavingLooFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(500), nrow = 50, ncol = 10)
+      }
+      fitter <- PsisSavingLooFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- expect_silent(build_metric_context(
+        fit_result,
+        fitter,
+        data_bundle,
+        list(rmse_loo_metric())
+      ))
+
+      # The engine asked loo_fit() to retain its PSIS object...
+      expect_true(isTRUE(calls$received_save_psis))
+      # ...and reused exactly that object (identity, not merely equality: a
+      # re-smoothing loo::psis() run would allocate a distinct object).
+      expect_identical(context$loo_psis, calls$returned_psis)
+      expect_true(inherits(context$loo_psis, "psis"))
+      expect_false(is.null(context[["loo"]]))
+      expect_equal(context$loo$elpd, calls$elpd)
+
+      # Standalone calls keep the default and get no PSIS object back.
+      standalone <- loo_fit(fitter, fit_result)
+      expect_null(standalone$psis_object)
+      expect_false(isTRUE(calls$received_save_psis))
+    })
+
+    it("falls back to loo::psis() when loo_fit() returns no psis_object (#76)", {
+      # SharingLooFitter (the #73 test above) returns no psis_object, like a
+      # custom fitter written before #76; build_metric_context still built a
+      # usable PSIS object there via the direct loo::psis() route. Pin the
+      # same fallback for a fitter whose psis_object does not match the
+      # context's log-lik matrix (e.g. it ignored the supplied log_lik).
+      MismatchedPsisFitter <- S7::new_class(
+        "MismatchedPsisFitter",
+        parent = MockFitter
+      )
+      S7::method(log_lik_matrix, MismatchedPsisFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(seq_len(500) / 500, nrow = 50, ncol = 10)
+      }
+      S7::method(loo_fit, MismatchedPsisFitter) <- function(
+        fitter,
+        fit_result,
+        log_lik = NULL,
+        save_psis = FALSE
+      ) {
+        ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
+        # PSIS object fitted from a 5-observation matrix: the pareto_k
+        # length (5) mismatches the context's 10-column log-lik, so the
+        # engine must reject it and re-fit from its own matrix.
+        other <- matrix(rnorm(250, -1, 0.5), nrow = 50, ncol = 5)
+        bad_psis <- suppressWarnings(loo::loo(
+          other,
+          save_psis = TRUE
+        ))$psis_object
+        list(
+          elpd = -20,
+          p_loo = 3,
+          elpd_se = 1.5,
+          pareto_k = runif(ncol(ll)),
+          r_eff = NULL,
+          psis_object = bad_psis
+        )
+      }
+      S7::method(predict_epred, MismatchedPsisFitter) <- function(
+        fitter,
+        fit_result,
+        newdata = NULL
+      ) {
+        matrix(rnorm(500), nrow = 50, ncol = 10)
+      }
+      fitter <- MismatchedPsisFitter()
+      fitter@supports_epred <- TRUE
+
+      data_bundle <- valid_data_bundle()
+      draws <- matrix(rnorm(100), ncol = 2, nrow = 50)
+      colnames(draws) <- c("alpha", "beta")
+      fit_result <- new_fit_result(
+        success = TRUE,
+        fit = list(data_bundle = data_bundle, seed = 42L, n_obs = 10),
+        draws = draws
+      )
+
+      context <- expect_silent(build_metric_context(
+        fit_result,
+        fitter,
+        data_bundle,
+        list(rmse_loo_metric())
+      ))
+
+      # A usable PSIS object fitted from the context's own 10-column matrix.
+      expect_true(inherits(context$loo_psis, "psis"))
+      expect_equal(ncol(context$loo_psis$log_weights), 10L)
     })
 
     it("builds epred without LOO support when \"loo\" is also declared (#68)", {

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -1349,10 +1349,12 @@ describe("Worker", {
         save_psis = FALSE
       ) {
         ll <- log_lik %||% log_lik_matrix(fitter, fit_result)
-        # PSIS object fitted from a 5-observation matrix: the pareto_k
-        # length (5) mismatches the context's 10-column log-lik, so the
-        # engine must reject it and re-fit from its own matrix.
-        other <- matrix(rnorm(250, -1, 0.5), nrow = 50, ncol = 5)
+        # PSIS object fitted from a same-width but differently-sized matrix
+        # (40 draws vs the context's 50, same 10 observations): only the
+        # draws dimension betrays it, and the engine must reject it and
+        # re-fit from its own matrix instead of erroring opaquely inside
+        # loo::E_loo().
+        other <- matrix(rnorm(400, -1, 0.5), nrow = 40, ncol = 10)
         bad_psis <- suppressWarnings(loo::loo(
           other,
           save_psis = TRUE
@@ -1392,9 +1394,10 @@ describe("Worker", {
         list(rmse_loo_metric())
       ))
 
-      # A usable PSIS object fitted from the context's own 10-column matrix.
+      # A usable PSIS object fitted from the context's own 50 x 10 matrix
+      # (the mismatched 40-draw object was rejected).
       expect_true(inherits(context$loo_psis, "psis"))
-      expect_equal(ncol(context$loo_psis$log_weights), 10L)
+      expect_identical(dim(context$loo_psis$log_weights), c(50L, 10L))
     })
 
     it("builds epred without LOO support when \"loo\" is also declared (#68)", {

--- a/tests/testthat/test-fitter-orientation.R
+++ b/tests/testthat/test-fitter-orientation.R
@@ -149,7 +149,8 @@ describe("log_lik S x N orientation convention", {
     S7::method(loo_fit, TransposedFitter) <- function(
       fitter,
       fit_result,
-      log_lik = NULL
+      log_lik = NULL,
+      save_psis = FALSE
     ) {
       list(
         elpd = -10,
@@ -358,7 +359,8 @@ describe("predict_fit S x N orientation convention", {
     S7::method(loo_fit, PredictTransposedFitter) <- function(
       fitter,
       fit_result,
-      log_lik = NULL
+      log_lik = NULL,
+      save_psis = FALSE
     ) {
       list(
         elpd = -10,

--- a/tests/testthat/test-linear-regression-fitter.R
+++ b/tests/testthat/test-linear-regression-fitter.R
@@ -170,6 +170,40 @@ describe("LinearRegressionFitter contract", {
     expect_equal(out_passed, out)
   })
 
+  it("loo_fit retains a reusable psis_object when asked (#76)", {
+    withr::local_seed(3)
+    n <- 25L
+    data_bundle <- list(
+      train = data.frame(y = stats::rnorm(n), x = stats::rnorm(n)),
+      test = NULL,
+      response = "y"
+    )
+    fitter <- LinearRegressionFitter(n_draws = 100L)
+    res <- fit_model(
+      fitter,
+      data_bundle,
+      list(formula = y ~ x),
+      seed = 1L,
+      task_ctx = list(task_id = "t")
+    )
+    ll <- log_lik_matrix(fitter, res)
+
+    # Default: no PSIS object is retained (standalone callers have no use).
+    out_plain <- loo_fit(fitter, res, log_lik = ll)
+    expect_null(out_plain$psis_object)
+
+    # save_psis = TRUE: loo::loo()'s internal PSIS object is retained and is
+    # identical to what a separate loo::psis(-ll) run would produce, so
+    # build_loo_context() can reuse it without re-smoothing the tails.
+    out_saved <- loo_fit(fitter, res, log_lik = ll, save_psis = TRUE)
+    expect_true(inherits(out_saved$psis_object, "psis"))
+    direct <- suppressWarnings(loo::psis(-ll))
+    expect_identical(out_saved$psis_object, direct)
+    # The summary is unaffected by retention.
+    summary_fields <- c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff")
+    expect_equal(out_saved[summary_fields], out_plain[summary_fields])
+  })
+
   it("loo_fit degrades to the NA structure on a degenerate log-lik (#73)", {
     withr::local_seed(3)
     data_bundle <- list(
@@ -193,11 +227,12 @@ describe("LinearRegressionFitter contract", {
     out <- loo_fit(fitter, res, log_lik = matrix(rnorm(10), nrow = 1))
     expect_setequal(
       names(out),
-      c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff")
+      c("elpd", "p_loo", "elpd_se", "pareto_k", "r_eff", "psis_object")
     )
     expect_true(all(is.na(out[c("elpd", "p_loo", "elpd_se")])))
     expect_length(out$pareto_k, 0)
     expect_null(out$r_eff)
+    expect_null(out$psis_object)
   })
 })
 

--- a/tests/testthat/test-loo-metrics-parity.R
+++ b/tests/testthat/test-loo-metrics-parity.R
@@ -157,3 +157,23 @@ describe("build_loo_context shares one log-lik and r_eff across summary and PSIS
     expect_equal(ctx$psis$diagnostics$pareto_k, psis_obj$diagnostics$pareto_k)
   })
 })
+
+# #76: the PSIS tail smoothing runs once — build_loo_context() reuses the
+# psis_object loo_fit() retained via save_psis = TRUE instead of running a
+# second loo::psis() pass over the same matrix.
+describe("build_loo_context reuses loo_fit()'s retained psis_object (#76)", {
+  it("delivers the retained object itself, not a re-smoothed copy", {
+    fitter <- BrmsFitter(chains = 1L, iter = 100L, warmup = 50L, cores = 1L)
+    retained <- loo_fit(
+      fitter,
+      fit_result,
+      log_lik = ll,
+      save_psis = TRUE
+    )$psis_object
+    expect_false(is.null(retained))
+    ctx <- build_loo_context(fitter, fit_result, need_psis = TRUE)
+    # Identity proves reuse: a fallback loo::psis() run would allocate a
+    # distinct (though numerically equal) object.
+    expect_identical(ctx$psis, retained)
+  })
+})

--- a/vignettes/custom-fitters.Rmd
+++ b/vignettes/custom-fitters.Rmd
@@ -35,7 +35,7 @@ The public fitter contract is:
 | `predict_fit(fitter, fit_result, newdata, seed)` | optional; `supports_predictions = TRUE` | list with `predicted_mean` (length N), `predicted_samples` (S x N), `predicted_sd` (length N) |
 | `log_lik_matrix(fitter, fit_result, newdata)` | optional; `supports_log_lik = TRUE` | numeric log-likelihood matrix (S x N) |
 | `predict_epred(fitter, fit_result, newdata)` | optional; `supports_epred = TRUE` | numeric expectation matrix (S x N), or `NULL` when unsupported (`r2_loo` then degrades to NA) |
-| `loo_fit(fitter, fit_result, log_lik)` | optional; `supports_loo = TRUE` | list with `elpd`, `p_loo`, `elpd_se`, `pareto_k`, `r_eff` |
+| `loo_fit(fitter, fit_result, log_lik, save_psis)` | optional; `supports_loo = TRUE` | list with `elpd`, `p_loo`, `elpd_se`, `pareto_k`, `r_eff`, `psis_object` |
 | `fit_diagnostics(fitter, fit_result)` | optional | named diagnostic list; the default is `list()` |
 
 **All matrices are draws x observations (S x N)** — `predicted_samples`,
@@ -49,9 +49,15 @@ weighted-prediction (PSIS) context it passes the train-set log-lik matrix it
 already computed, and the method should reuse it instead of recomputing;
 standalone calls pass `NULL` and the method computes its own. Returning
 `r_eff` (the chain-aware relative efficiencies used for the summary, or
-`NULL`) likewise lets the engine reuse them for the PSIS object. A `loo_fit()`
-method registered without the `log_lik` argument is rejected by S7's strict
-signature checking.
+`NULL`) likewise lets the engine reuse them for the PSIS object. When the
+engine calls with `save_psis = TRUE`, a method that computes its summary via
+`loo::loo(ll, r_eff, save_psis = TRUE)` should return the retained
+`$psis_object` as `psis_object`; the engine reuses it for the weighted
+predictions instead of smoothing the tails a second time (`NULL` is fine for
+methods that don't use the loo machinery — the engine falls back to building
+the PSIS object itself). A `loo_fit()` method registered without the
+`log_lik`/`save_psis` arguments is rejected by S7's strict signature
+checking.
 
 The generics avoid masking common names: `loo_fit` (not `loo::loo`),
 `log_lik_matrix` (not `brms::log_lik`), `fit_model` (not `generics::fit`).


### PR DESCRIPTION
Fixes #76.

## Problem

After #75, the weighted-prediction (PSIS) path computes the train-set log-lik matrix and `r_eff` once per task, but the PSIS **tail smoothing itself still runs twice**:

1. inside `loo_fit()`, `loo::loo(ll, r_eff)` internally fits the per-observation generalized-Pareto tails to produce the elpd estimates;
2. `build_loo_context()` then runs `loo::psis(-ll, r_eff)` over the same matrix with the same `r_eff` to build the object `loo::E_loo()` consumes.

Both runs smooth the same matrix identically, so the second pass is pure overhead (per-observation tail fits, comparable in cost to `relative_eff`).

## Change

- `loo_fit()` gains an optional `save_psis` argument, mirroring the #73 `log_lik` seam. When TRUE, methods pass it through to `loo::loo()` and return the retained `$psis_object` as `psis_object` (NULL when FALSE — standalone callers keep paying nothing extra).
- Key property (verified empirically and exploited here): `loo::loo(ll, r_eff, save_psis = TRUE)$psis_object` is `identical()` to `loo::psis(-ll, r_eff)` — `loo.matrix` and `psis.matrix` route to the same `importance_sampling.matrix` call. No loo-internal APIs are used, and no loo version dance: `save_psis` has been in loo since 2.0.
- `build_loo_context()` calls `loo_fit(..., save_psis = need_psis)` and reuses the returned object directly for `context$loo_psis`. The direct `loo::psis()` route remains as the fallback when the fitter returns no `psis_object` (custom fitters, the mock), and when a pareto_k length check (exported `loo::pareto_k_values()`, stable across loo versions) detects an object fitted from a different matrix — e.g. a fitter that ignored the supplied `log_lik`. The `r_eff` reconciliation and `relative_eff_from_chains()` fallback now also only run on that fallback path (a reused object already embeds its own `r_eff` treatment).

## Guard (from the issue)

- Standalone `loo_fit()` calls are unchanged: default `save_psis = FALSE` retains nothing, summaries are bit-identical (asserted), and the A4 BrmsFitter ≡ `brms::loo()` parity test passes unmodified.
- Per-fitter summary semantics unchanged: CmdStan keeps its own `r_eff` derivation (now embedded in the reused object), LinearRegression keeps its i.i.d. handling (`suppressWarnings` retained; the reused object is exactly what the old fallback computed).
- **Breaking for custom fitters** (same class as #75): `loo_fit()` methods must accept the new `save_psis` argument (S7 formals rule); returning `psis_object` is optional — the engine falls back to building the PSIS object itself. Documented in NEWS and the custom-fitters vignette.

## Tests

- `test-engine.R` (core tier): a fitter running the real loo machinery proves `build_metric_context()` passes `save_psis = TRUE` and delivers **exactly** the object `loo_fit()` retained (`expect_identical` — a re-smoothed fallback would allocate a distinct object); standalone default keeps `psis_object = NULL`. A mismatched-matrix fitter (psis fitted from a 5-column matrix vs. the context's 10) proves the length guard falls back to a correct 10-column PSIS object. The #73 counting-fitter test now also asserts `save_psis = TRUE` was received alongside its fallback-path coverage.
- `test-linear-regression-fitter.R`: `save_psis = TRUE` returns an object `identical()` to a direct `suppressWarnings(loo::psis(-ll))` run, with an unchanged summary.
- `test-cmdstan-fitter.R` (backend tier): same identity assertion against `loo::psis(-ll, r_eff = <returned r_eff>)`.
- `test-loo-metrics-parity.R` (backend tier): `build_loo_context()`'s `psis` is `identical()` to the object `loo_fit(save_psis = TRUE)` retained on the real BrmsFitter path, in addition to the existing #73 parity assertions.
- `test-contracts.R`: the documented `loo_fit()` structure set now includes `psis_object` (NULL in the mock and NA-degradation paths).

## Local verification

- Core suite: `FAIL 0 | WARN 11 | SKIP 6 | PASS 1444` (warnings pre-existing)
- `R CMD check`: 0 errors / 0 notes; the single WARNING is the documented upstream S7/codoc case (#56)
- `air format . --check`: clean; man pages regenerated